### PR TITLE
Generate routeId for request

### DIFF
--- a/src/backend/src/routes/interfaces/http/request-routes.test.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.test.ts
@@ -1,0 +1,36 @@
+import { handler } from './request-routes';
+import { RouteId } from '../../domain/value-objects/route-id-value-object';
+
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/client-sqs', () => ({
+  SQSClient: jest.fn().mockImplementation(() => ({ send: mockSend })),
+  SendMessageCommand: jest.fn().mockImplementation((input) => input),
+}));
+
+beforeEach(() => {
+  mockSend.mockReset();
+  process.env.QUEUE_URL = 'http://localhost';
+});
+
+describe('request routes handler', () => {
+  it('generates routeId when missing', async () => {
+    mockSend.mockResolvedValueOnce({});
+    const res = await handler({ body: JSON.stringify({ origin: 'A', destination: 'B' }) } as any);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const sent = mockSend.mock.calls[0][0];
+    const payload = JSON.parse(sent.MessageBody);
+    expect(payload.routeId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(JSON.parse(res.body).routeId).toBe(payload.routeId);
+  });
+
+  it('keeps provided routeId', async () => {
+    const routeId = RouteId.generate().Value;
+    mockSend.mockResolvedValueOnce({});
+    const res = await handler({ body: JSON.stringify({ routeId }) } as any);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(mockSend.mock.calls[0][0].MessageBody);
+    expect(payload.routeId).toBe(routeId);
+    expect(JSON.parse(res.body).routeId).toBe(routeId);
+  });
+});

--- a/src/backend/src/routes/interfaces/http/request-routes.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.ts
@@ -1,5 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
+import { RouteId } from '../../domain/value-objects/route-id-value-object';
 
 const sqs = new SQSClient({});
 
@@ -7,6 +8,10 @@ export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   const data = event.body ? JSON.parse(event.body) : {};
+  if (!data.routeId) {
+    data.routeId = RouteId.generate().Value;
+  }
+
   await sqs.send(
     new SendMessageCommand({
       QueueUrl: process.env.QUEUE_URL,
@@ -16,6 +21,6 @@ export const handler = async (
 
   return {
     statusCode: 202,
-    body: JSON.stringify({ enqueued: true }),
+    body: JSON.stringify({ enqueued: true, routeId: data.routeId }),
   };
 };


### PR DESCRIPTION
## Summary
- generate `RouteId` in `request-routes` when it is missing
- send the new ID in the SQS message
- expose the generated ID in the HTTP response
- add unit tests for the handler logic

## Testing
- `npm --prefix src/backend run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685949095280832f8efeca3ce9fc4dfb