### PR TITLE
Use NodejsFunction for SqsConsumer

### DIFF
--- a/infrastructure/lib/constructs/sqs-consumer.ts
+++ b/infrastructure/lib/constructs/sqs-consumer.ts
@@ -1,5 +1,7 @@
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import * as path from 'path';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 
@@ -16,10 +18,11 @@ export class SqsConsumer extends Construct {
   constructor(scope: Construct, id: string, props: SqsConsumerProps) {
     super(scope, id);
 
-    this.fn = new lambda.Function(this, 'Function', {
+    const [file, fnName] = props.handler.split('.');
+    this.fn = new NodejsFunction(this, 'Function', {
       runtime: lambda.Runtime.NODEJS_18_X,
-      code: lambda.Code.fromAsset(props.entry),
-      handler: props.handler,
+      entry: path.join(props.entry, `${file}.ts`),
+      handler: fnName,
       environment: props.environment,
     });
 


### PR DESCRIPTION
## Summary
- use `NodejsFunction` in `SqsConsumer` to bundle TS handlers
- add handler file resolution similar to `HttpLambda`

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run test:unit` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859491bfe84832f94da213a6c079dc4