### PR TITLE
Decode route polyline before storing

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -6,6 +6,42 @@ const dynamo = new DynamoDBClient({});
 const tableName = process.env.ROUTES_TABLE as string;
 const googleKey = process.env.GOOGLE_API_KEY as string;
 
+type LatLng = { lat: number; lng: number };
+
+function decodePolyline(encoded: string): LatLng[] {
+  let index = 0;
+  let lat = 0;
+  let lng = 0;
+  const coordinates: LatLng[] = [];
+
+  while (index < encoded.length) {
+    let b: number;
+    let shift = 0;
+    let result = 0;
+    do {
+      b = encoded.charCodeAt(index++) - 63;
+      result |= (b & 0x1f) << shift;
+      shift += 5;
+    } while (b >= 0x20);
+    const deltaLat = (result & 1) ? ~(result >> 1) : result >> 1;
+    lat += deltaLat;
+
+    shift = 0;
+    result = 0;
+    do {
+      b = encoded.charCodeAt(index++) - 63;
+      result |= (b & 0x1f) << shift;
+      shift += 5;
+    } while (b >= 0x20);
+    const deltaLng = (result & 1) ? ~(result >> 1) : result >> 1;
+    lng += deltaLng;
+
+    coordinates.push({ lat: lat / 1e5, lng: lng / 1e5 });
+  }
+
+  return coordinates;
+}
+
 function fetchJson(url: string): Promise<any> {
   return new Promise((resolve, reject) => {
     const req = httpsRequest(url, (res) => {
@@ -37,6 +73,9 @@ export const handler: SQSHandler = async (event) => {
     const leg = directions.routes?.[0]?.legs?.[0];
     if (!leg) continue;
 
+    const polyline = directions.routes[0].overview_polyline?.points as string | undefined;
+    const coordinates = polyline ? decodePolyline(polyline) : [];
+
     await dynamo.send(
       new PutItemCommand({
         TableName: tableName,
@@ -44,7 +83,7 @@ export const handler: SQSHandler = async (event) => {
           routeId: { S: payload.routeId },
           distanceKm: { N: ((leg.distance.value || 0) / 1000).toString() },
           duration: { N: (leg.duration.value || 0).toString() },
-          path: { S: JSON.stringify(directions.routes[0].overview_polyline?.points) },
+          path: { S: JSON.stringify(coordinates) },
         },
       })
     );


### PR DESCRIPTION
## Summary
- decode Google Maps overview polyline into {lat,lng} points
- save the decoded coordinates array when persisting a route

## Testing
- `npx tsc -p src/backend/tsconfig.json` *(fails: Cannot find type definition file for 'jest', 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6859491a826c832fb466151953880a08