### PR TITLE
Update routes worker to use v2 Directions API

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
@@ -43,11 +43,13 @@ describe('worker routes handler', () => {
     responseDataHolder.data = JSON.stringify({
       routes: [
         {
-          overview_polyline: { points: '_p~iF~ps|U_ulLnnqC_mqNvxq`@' },
           legs: [
             {
-              distance: { value: 1500 },
-              duration: { value: 600 }
+              distanceMeters: 1500,
+              duration: { seconds: 600 },
+              polyline: {
+                encodedPolyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@'
+              }
             }
           ]
         }

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -118,6 +118,8 @@ function postJson<T = any>(
         "Content-Type": "application/json",
         "Content-Length": Buffer.byteLength(payload),
         "X-Goog-Api-Key": apiKey,
+        "X-Goog-FieldMask":
+          "routes.legs.duration,routes.legs.distanceMeters,routes.legs.polyline.encodedPolyline",
       },
     };
 
@@ -183,7 +185,7 @@ export const handler: SQSHandler = async (event) => {
     try {
       resp = await postJson(
         "routes.googleapis.com",
-        "/v1:computeRoutes",
+        "/directions/v2:computeRoutes",
         googleKey,
         requestBody
       );


### PR DESCRIPTION
## Summary
- call Google Routes API with `/directions/v2:computeRoutes`
- request only needed fields from the API
- adjust unit test fixture to match new response shape

## Testing
- `npm run build --prefix src/backend` *(fails: Cannot find type definition file for 'jest')*
- `npm run test:unit --prefix src/backend` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4f1a060c832fbe90959d5e075471