### PR TITLE
Add LatLng value object and refactor paths

### DIFF
--- a/src/backend/src/routes/domain/entities/route-entity.test.ts
+++ b/src/backend/src/routes/domain/entities/route-entity.test.ts
@@ -3,6 +3,7 @@ import { RouteId } from "../value-objects/route-id-value-object";
 import { DistanceKm } from "../value-objects/distance-value-object";
 import { Duration } from "../value-objects/duration-value-object";
 import { Path } from "../value-objects/path-value-object";
+import { LatLng } from "../value-objects/lat-lng-value-object";
 
 describe("Route", () => {
   it("should create a Route with all properties", () => {
@@ -10,8 +11,8 @@ describe("Route", () => {
     const distance = new DistanceKm(10);
     const duration = new Duration(1200);
     const path = Path.fromCoordinates([
-      { lat: 41.38, lng: 2.17 },
-      { lat: 41.39, lng: 2.18 },
+      LatLng.fromNumbers(41.38, 2.17),
+      LatLng.fromNumbers(41.39, 2.18),
     ]);
 
     const route = new Route({
@@ -24,7 +25,7 @@ describe("Route", () => {
     expect(route.routeId.equals(routeId)).toBe(true);
     expect(route.distanceKm?.Value).toBe(10);
     expect(route.duration?.Value).toBe(1200);
-    expect(route.path?.Coordinates).toEqual([
+    expect(route.path?.Coordinates.map(v => ({ lat: v.Lat, lng: v.Lng }))).toEqual([
       { lat: 41.38, lng: 2.17 },
       { lat: 41.39, lng: 2.18 },
     ]);

--- a/src/backend/src/routes/domain/events/route-generated.test.ts
+++ b/src/backend/src/routes/domain/events/route-generated.test.ts
@@ -4,6 +4,7 @@ import { RouteId } from '../value-objects/route-id-value-object';
 import { DistanceKm } from '../value-objects/distance-value-object';
 import { Duration } from '../value-objects/duration-value-object';
 import { Path } from '../value-objects/path-value-object';
+import { LatLng } from '../value-objects/lat-lng-value-object';
 
 describe('RouteGeneratedEvent', () => {
   it('should hold the generated route', () => {
@@ -11,9 +12,9 @@ describe('RouteGeneratedEvent', () => {
       routeId: RouteId.generate(),
       distanceKm: new DistanceKm(1),
       duration: new Duration(60),
-      path: new Path([
-        { lat: 0, lng: 0 },
-        { lat: 1, lng: 1 },
+      path: Path.fromCoordinates([
+        LatLng.fromNumbers(0, 0),
+        LatLng.fromNumbers(1, 1),
       ]),
     });
     const event = new RouteGeneratedEvent({ route });

--- a/src/backend/src/routes/domain/value-objects/lat-lng-value-object.test.ts
+++ b/src/backend/src/routes/domain/value-objects/lat-lng-value-object.test.ts
@@ -1,0 +1,25 @@
+import { LatLng } from './lat-lng-value-object';
+
+describe('LatLng', () => {
+  it('creates valid coordinates', () => {
+    const ll = LatLng.fromNumbers(45, -73);
+    expect(ll.Lat).toBe(45);
+    expect(ll.Lng).toBe(-73);
+  });
+
+  it('allows boundary values', () => {
+    const ll = LatLng.fromNumbers(-90, 180);
+    expect(ll.Lat).toBe(-90);
+    expect(ll.Lng).toBe(180);
+  });
+
+  it('rejects invalid latitude', () => {
+    expect(() => LatLng.fromNumbers(91, 0)).toThrow('Latitude must be between -90 and 90');
+    expect(() => LatLng.fromNumbers(-91, 0)).toThrow('Latitude must be between -90 and 90');
+  });
+
+  it('rejects invalid longitude', () => {
+    expect(() => LatLng.fromNumbers(0, 181)).toThrow('Longitude must be between -180 and 180');
+    expect(() => LatLng.fromNumbers(0, -181)).toThrow('Longitude must be between -180 and 180');
+  });
+});

--- a/src/backend/src/routes/domain/value-objects/lat-lng-value-object.ts
+++ b/src/backend/src/routes/domain/value-objects/lat-lng-value-object.ts
@@ -1,0 +1,22 @@
+export class LatLng {
+  private constructor(private readonly lat: number, private readonly lng: number) {
+    if (lat < -90 || lat > 90) {
+      throw new Error("Latitude must be between -90 and 90");
+    }
+    if (lng < -180 || lng > 180) {
+      throw new Error("Longitude must be between -180 and 180");
+    }
+  }
+
+  static fromNumbers(lat: number, lng: number): LatLng {
+    return new LatLng(lat, lng);
+  }
+
+  get Lat(): number {
+    return this.lat;
+  }
+
+  get Lng(): number {
+    return this.lng;
+  }
+}

--- a/src/backend/src/routes/domain/value-objects/path-value-object.test.ts
+++ b/src/backend/src/routes/domain/value-objects/path-value-object.test.ts
@@ -1,9 +1,10 @@
-import { Path, LatLng } from './path-value-object';
+import { Path } from './path-value-object';
+import { LatLng } from './lat-lng-value-object';
 
 describe('Path', () => {
   const coords: LatLng[] = [
-    { lat: 41.38, lng: 2.17 },
-    { lat: 41.39, lng: 2.18 },
+    LatLng.fromNumbers(41.38, 2.17),
+    LatLng.fromNumbers(41.39, 2.18),
   ];
 
   describe('fromCoordinates()', () => {
@@ -19,9 +20,9 @@ describe('Path', () => {
     });
 
     it('should throw an error if the array has only one point', () => {
-      expect(() => Path.fromCoordinates([{ lat: 41.38, lng: 2.17 }])).toThrow(
-        'The path must have at least two coordinates'
-      );
+      expect(() =>
+        Path.fromCoordinates([LatLng.fromNumbers(41.38, 2.17)])
+      ).toThrow('The path must have at least two coordinates');
     });
 
     it('Coordinates should return a copy of the array', () => {
@@ -29,9 +30,11 @@ describe('Path', () => {
       const path = Path.fromCoordinates(original);
       const c1 = path.Coordinates;
       const c2 = path.Coordinates;
-      expect(c1).not.toBe(original);    
-      expect(c1).toEqual(original);    
-      expect(c1).not.toBe(c2);          
+      expect(c1).not.toBe(original);
+      expect(c1.map(v => ({ lat: v.Lat, lng: v.Lng }))).toEqual(
+        original.map(v => ({ lat: v.Lat, lng: v.Lng }))
+      );
+      expect(c1).not.toBe(c2);
     });
   });
 
@@ -45,7 +48,9 @@ describe('Path', () => {
     it('should decode correctly back to the same coords', () => {
       const path = Path.fromCoordinates(coords);
       const roundtrip = new Path(path.Encoded);
-      expect(roundtrip.Coordinates).toEqual(coords);
+      expect(roundtrip.Coordinates.map(v => ({ lat: v.Lat, lng: v.Lng }))).toEqual(
+        coords.map(v => ({ lat: v.Lat, lng: v.Lng }))
+      );
     });
   });
 });

--- a/src/backend/src/routes/domain/value-objects/path-value-object.ts
+++ b/src/backend/src/routes/domain/value-objects/path-value-object.ts
@@ -1,7 +1,6 @@
 // domain/value-objects/path-value-object.ts
 import polyline from '@mapbox/polyline';
-
-export type LatLng = { lat: number; lng: number };
+import { LatLng } from './lat-lng-value-object';
 
 export class Path {
   constructor(private readonly encoded: string) {
@@ -16,14 +15,14 @@ export class Path {
 
   get Coordinates(): LatLng[] {
     const decoded = polyline.decode(this.encoded) as [number, number][];
-    return decoded.map(([lat, lng]) => ({ lat, lng }));
+    return decoded.map(([lat, lng]) => LatLng.fromNumbers(lat, lng));
   }
 
   static fromCoordinates(coords: LatLng[]): Path {
     if (coords.length < 2) {
       throw new Error("The path must have at least two coordinates");
     }
-    const arr = coords.map(c => [c.lat, c.lng] as [number, number]);
+    const arr = coords.map(c => [c.Lat, c.Lng] as [number, number]);
     return new Path(polyline.encode(arr));
   }
 }

--- a/src/backend/src/routes/infrastructure/dynamodb/dynamo-route-repository.test.ts
+++ b/src/backend/src/routes/infrastructure/dynamodb/dynamo-route-repository.test.ts
@@ -3,6 +3,7 @@ import { RouteId } from '../../domain/value-objects/route-id-value-object';
 import { DistanceKm } from '../../domain/value-objects/distance-value-object';
 import { Duration } from '../../domain/value-objects/duration-value-object';
 import { Path } from '../../domain/value-objects/path-value-object';
+import { LatLng } from '../../domain/value-objects/lat-lng-value-object';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoRouteRepository } from './dynamo-route-repository';
 
@@ -39,8 +40,8 @@ describe('DynamoRouteRepository', () => {
 
   it('save correctly calls PutItemCommand', async () => {
     const coords = [
-      { lat: 1, lng: 2 },
-      { lat: 3, lng: 4 },
+      LatLng.fromNumbers(1, 2),
+      LatLng.fromNumbers(3, 4),
     ];
     const path = Path.fromCoordinates(coords);
     const route = new Route({
@@ -73,8 +74,8 @@ describe('DynamoRouteRepository', () => {
   it('findById reconstructs a Route from response', async () => {
     const id = RouteId.generate().Value;
     const coords = [
-      { lat: 1, lng: 2 },
-      { lat: 3, lng: 4 },
+      LatLng.fromNumbers(1, 2),
+      LatLng.fromNumbers(3, 4),
     ];
     // Prepara un encoded válido para el mock de Dynamo
     const encoded = Path.fromCoordinates(coords).Encoded;
@@ -96,6 +97,9 @@ describe('DynamoRouteRepository', () => {
     expect(route?.distanceKm?.Value).toBe(5);
     expect(route?.duration?.Value).toBe(10);
     // Y comprobamos que se haya decodificado correctamente
-    expect(route?.path?.Coordinates).toEqual(coords);
+    expect(route?.path?.Coordinates.map(c => ({ lat: c.Lat, lng: c.Lng }))).toEqual([
+      { lat: 1, lng: 2 },
+      { lat: 3, lng: 4 },
+    ]);
   });
 });

--- a/src/backend/src/routes/infrastructure/in-memory/in-memory-route-repository.test.ts
+++ b/src/backend/src/routes/infrastructure/in-memory/in-memory-route-repository.test.ts
@@ -4,6 +4,7 @@ import { RouteId } from '../../domain/value-objects/route-id-value-object';
 import { DistanceKm } from '../../domain/value-objects/distance-value-object';
 import { Duration } from '../../domain/value-objects/duration-value-object';
 import { Path } from '../../domain/value-objects/path-value-object';
+import { LatLng } from '../../domain/value-objects/lat-lng-value-object';
 
 describe('InMemoryRouteRepository', () => {
   let repo: InMemoryRouteRepository;
@@ -18,8 +19,8 @@ describe('InMemoryRouteRepository', () => {
       distanceKm: new DistanceKm(3),
       duration: new Duration(300),
       path: Path.fromCoordinates([
-        { lat: 0, lng: 0 },
-        { lat: 1, lng: 1 },
+        LatLng.fromNumbers(0, 0),
+        LatLng.fromNumbers(1, 1),
       ]),
     });
 
@@ -30,7 +31,9 @@ describe('InMemoryRouteRepository', () => {
     expect(fetched?.routeId.equals(route.routeId)).toBe(true);
     expect(fetched?.distanceKm?.Value).toBe(3);
     expect(fetched?.duration?.Value).toBe(300);
-    expect(fetched?.path?.Coordinates).toEqual(route.path!.Coordinates);
+    expect(fetched?.path?.Coordinates.map(c => ({ lat: c.Lat, lng: c.Lng }))).toEqual(
+      route.path!.Coordinates.map(c => ({ lat: c.Lat, lng: c.Lng }))
+    );
   });
 
   it('returns null when finding non-existent id', async () => {
@@ -44,8 +47,8 @@ describe('InMemoryRouteRepository', () => {
       distanceKm: new DistanceKm(1),
       duration: new Duration(100),
       path: Path.fromCoordinates([
-        { lat: 10, lng: 10 },
-        { lat: 20, lng: 20 },
+        LatLng.fromNumbers(10, 10),
+        LatLng.fromNumbers(20, 20),
       ]),
     });
     const routeB = new Route({
@@ -53,8 +56,8 @@ describe('InMemoryRouteRepository', () => {
       distanceKm: new DistanceKm(2),
       duration: new Duration(200),
       path: Path.fromCoordinates([
-        { lat: 30, lng: 30 },
-        { lat: 40, lng: 40 },
+        LatLng.fromNumbers(30, 30),
+        LatLng.fromNumbers(40, 40),
       ]),
     });
 
@@ -74,8 +77,8 @@ describe('InMemoryRouteRepository', () => {
       distanceKm: new DistanceKm(5),
       duration: new Duration(500),
       path: Path.fromCoordinates([
-        { lat: 50, lng: 50 },
-        { lat: 60, lng: 60 },
+        LatLng.fromNumbers(50, 50),
+        LatLng.fromNumbers(60, 60),
       ]),
     });
 

--- a/src/backend/src/routes/interfaces/http/page-router.test.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.test.ts
@@ -28,6 +28,7 @@ import { RouteId } from "../../domain/value-objects/route-id-value-object";
 import { DistanceKm } from "../../domain/value-objects/distance-value-object";
 import { Duration } from "../../domain/value-objects/duration-value-object";
 import { Path } from "../../domain/value-objects/path-value-object";
+import { LatLng } from "../../domain/value-objects/lat-lng-value-object";
 
 const baseCtx = {
   requestContext: {
@@ -68,8 +69,8 @@ describe("page router get route", () => {
       distanceKm: new DistanceKm(2),
       duration: new Duration(100),
       path: Path.fromCoordinates([
-        { lat: 0, lng: 0 },
-        { lat: 1, lng: 1 },
+        LatLng.fromNumbers(0, 0),
+        LatLng.fromNumbers(1, 1),
       ]),
     });
     mockFindById.mockResolvedValueOnce(route);
@@ -114,8 +115,8 @@ describe("page router list routes", () => {
       distanceKm: new DistanceKm(1),
       duration: new Duration(10),
       path: Path.fromCoordinates([
-        { lat: 10, lng: 10 },
-        { lat: 20, lng: 20 },
+        LatLng.fromNumbers(10, 10),
+        LatLng.fromNumbers(20, 20),
       ]),
     });
     const route2 = new Route({
@@ -123,8 +124,8 @@ describe("page router list routes", () => {
       distanceKm: new DistanceKm(2),
       duration: new Duration(20),
       path: Path.fromCoordinates([
-        { lat: 30, lng: 30 },
-        { lat: 40, lng: 40 },
+        LatLng.fromNumbers(30, 30),
+        LatLng.fromNumbers(40, 40),
       ]),
     });
     mockFindAll.mockResolvedValueOnce([route1, route2]);

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
@@ -99,7 +99,7 @@ describe("worker routes handler", () => {
     expect(saved.routeId.Value).toBe("550e8400-e29b-41d4-a716-446655440000");
     expect(saved.distanceKm.Value).toBe(1.5);
     expect(saved.duration.Value).toBe(600);
-    expect(saved.path.Coordinates).toEqual([
+    expect(saved.path.Coordinates.map(c => ({ lat: c.Lat, lng: c.Lng }))).toEqual([
       { lat: 38.5, lng: -120.2 },
       { lat: 40.7, lng: -120.95 },
       { lat: 43.252, lng: -126.453 },


### PR DESCRIPTION
## Summary
- create immutable `LatLng` value object
- refactor `Path` to use `LatLng`
- update tests and fixtures for the new class
- add unit tests for `LatLng`

## Testing
- `npm run test:unit --prefix src/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639086f924832fa9dd5817c0bd5b05