### PR TITLE
Remove unused polyline decoder

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -74,35 +74,6 @@ async function geocode(
   return { lat: loc.lat, lng: loc.lng };
 }
 
-function decodePolyline(encoded: string): Array<{ lat: number; lng: number }> {
-  let index = 0,
-    lat = 0,
-    lng = 0;
-  const coords: Array<{ lat: number; lng: number }> = [];
-  while (index < encoded.length) {
-    let result = 0,
-      shift = 0,
-      b: number;
-    do {
-      b = encoded.charCodeAt(index++) - 63;
-      result |= (b & 0x1f) << shift;
-      shift += 5;
-    } while (b >= 0x20);
-    const deltaLat = result & 1 ? ~(result >> 1) : result >> 1;
-    lat += deltaLat;
-    result = 0;
-    shift = 0;
-    do {
-      b = encoded.charCodeAt(index++) - 63;
-      result |= (b & 0x1f) << shift;
-      shift += 5;
-    } while (b >= 0x20);
-    const deltaLng = result & 1 ? ~(result >> 1) : result >> 1;
-    lng += deltaLng;
-    coords.push({ lat: lat / 1e5, lng: lng / 1e5 });
-  }
-  return coords;
-}
 
 function postJson<T = any>(
   host: string,


### PR DESCRIPTION
## Summary
- remove duplicate `decodePolyline` helper
- rely on `Path` value object for decoding polylines

## Testing
- `npm test --silent` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_686390893e00832faa73187350ffb4e9