### PR TITLE
Add RequestRoutesUseCase test

### DIFF
--- a/src/backend/src/routes/application/use-cases/request-routes.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/request-routes.usecase.test.ts
@@ -1,0 +1,19 @@
+import { RequestRoutesUseCase } from './request-routes';
+import { RouteRepository } from '../../domain/repositories/route-repository';
+import { Route } from '../../domain/entities/route-entity';
+import { RouteId } from '../../domain/value-objects/route-id-value-object';
+
+describe('RequestRoutesUseCase', () => {
+  it('saves and returns a Route instance', async () => {
+    const save = jest.fn();
+    const repo: RouteRepository = { save } as any;
+    const useCase = new RequestRoutesUseCase(repo);
+    const routeId = RouteId.generate();
+
+    const result = await useCase.execute({ routeId });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith(expect.any(Route));
+    expect(result.routeId.equals(routeId)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test covering the RequestRoutesUseCase

## Testing
- `npm -C src/backend run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863908a0e48832f967d793aff28049d