### PR TITLE
Add AppSync mutations for favourites

### DIFF
--- a/infrastructure/lib/stacks/compute-stack.ts
+++ b/infrastructure/lib/stacks/compute-stack.ts
@@ -17,6 +17,9 @@ export interface ComputeStackProps extends cdk.StackProps {
   readonly metricsQueue: sqs.IQueue;
   readonly userPool: IUserPool;
   readonly googleApiKeySecretName: string;
+  readonly appSyncUrl?: string;
+  readonly appSyncApiKey?: string;
+  readonly appSyncRegion?: string;
 }
 
 export class ComputeStack extends cdk.Stack {
@@ -85,6 +88,9 @@ export class ComputeStack extends cdk.Stack {
       handler: "favourite-routes.handler",
       environment: {
         USER_STATE_TABLE: props.userStateTable.tableName,
+        ...(props.appSyncUrl ? { APPSYNC_URL: props.appSyncUrl } : {}),
+        ...(props.appSyncApiKey ? { APPSYNC_API_KEY: props.appSyncApiKey } : {}),
+        ...(props.appSyncRegion ? { APPSYNC_REGION: props.appSyncRegion } : {}),
       },
       api,
       routes: [

--- a/src/backend/src/routes/interfaces/appsync-client.ts
+++ b/src/backend/src/routes/interfaces/appsync-client.ts
@@ -1,0 +1,62 @@
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import { SignatureV4 } from "@aws-sdk/signature-v4";
+import { defaultProvider } from "@aws-sdk/credential-provider-node";
+import { Sha256 } from "@aws-crypto/sha256-js";
+
+const url = process.env.APPSYNC_URL;
+const apiKey = process.env.APPSYNC_API_KEY;
+const region = process.env.APPSYNC_REGION || process.env.AWS_REGION || "us-east-1";
+
+async function send(query: string, variables: Record<string, any>): Promise<any> {
+  if (!url) return;
+  const body = JSON.stringify({ query, variables });
+  if (apiKey) {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+      },
+      body,
+    });
+    return res.json();
+  }
+
+  const { hostname, pathname, protocol } = new URL(url);
+  const request = new HttpRequest({
+    protocol,
+    hostname,
+    method: "POST",
+    path: pathname,
+    headers: { "Content-Type": "application/json", host: hostname },
+    body,
+  });
+
+  const signer = new SignatureV4({
+    credentials: defaultProvider(),
+    region,
+    service: "appsync",
+    sha256: Sha256,
+  });
+  const signed = await signer.sign(request);
+  const res = await fetch(url, {
+    method: "POST",
+    headers: signed.headers as any,
+    body,
+  });
+  return res.json();
+}
+
+export async function publishFavouriteSaved(email: string, routeId: string) {
+  await send(
+    `mutation PublishFavouriteSaved($email: String!, $routeId: ID!) {\n  publishFavouriteSaved(email: $email, routeId: $routeId)\n}`,
+    { email, routeId }
+  );
+}
+
+export async function publishFavouriteDeleted(email: string, routeId: string) {
+  await send(
+    `mutation PublishFavouriteDeleted($email: String!, $routeId: ID!) {\n  publishFavouriteDeleted(email: $email, routeId: $routeId)\n}`,
+    { email, routeId }
+  );
+}

--- a/src/backend/src/routes/interfaces/http/favourite-routes.test.ts
+++ b/src/backend/src/routes/interfaces/http/favourite-routes.test.ts
@@ -1,6 +1,8 @@
 const mockPut = jest.fn();
 const mockDelete = jest.fn();
 const mockGet = jest.fn();
+const mockPublishSaved = jest.fn();
+const mockPublishDeleted = jest.fn();
 
 jest.mock("../../infrastructure/dynamodb/dynamo-user-state-repository", () => ({
   DynamoUserStateRepository: jest.fn().mockImplementation(() => ({
@@ -14,6 +16,11 @@ jest.mock("@aws-sdk/client-dynamodb", () => ({
   DynamoDBClient: jest.fn().mockImplementation(() => ({})),
 }));
 
+jest.mock("../appsync-client", () => ({
+  publishFavouriteSaved: (...args: any[]) => mockPublishSaved(...args),
+  publishFavouriteDeleted: (...args: any[]) => mockPublishDeleted(...args),
+}));
+
 import { handler } from "./favourite-routes";
 
 const baseCtx = {
@@ -24,6 +31,8 @@ beforeEach(() => {
   mockPut.mockReset();
   mockDelete.mockReset();
   mockGet.mockReset();
+  mockPublishSaved.mockReset();
+  mockPublishDeleted.mockReset();
 });
 
 describe("favourite routes handler", () => {
@@ -36,6 +45,7 @@ describe("favourite routes handler", () => {
     });
     expect(mockGet).toHaveBeenCalledWith("test@example.com");
     expect(mockPut).toHaveBeenCalledWith("test@example.com", "1");
+    expect(mockPublishSaved).toHaveBeenCalledWith("test@example.com", "1");
     expect(res.statusCode).toBe(200);
   });
 
@@ -78,6 +88,7 @@ describe("favourite routes handler", () => {
       pathParameters: { routeId: "2" },
     });
     expect(mockDelete).toHaveBeenCalledWith("test@example.com", "2");
+    expect(mockPublishDeleted).toHaveBeenCalledWith("test@example.com", "2");
     expect(res.statusCode).toBe(200);
   });
 

--- a/src/backend/src/routes/interfaces/http/favourite-routes.ts
+++ b/src/backend/src/routes/interfaces/http/favourite-routes.ts
@@ -1,6 +1,10 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoUserStateRepository } from "../../infrastructure/dynamodb/dynamo-user-state-repository";
+import {
+  publishFavouriteSaved,
+  publishFavouriteDeleted,
+} from "../appsync-client";
 
 const dynamo = new DynamoDBClient({});
 const repository = new DynamoUserStateRepository(
@@ -46,6 +50,7 @@ export const handler = async (
     }
 
     await repository.putFavourite(email, routeId);
+    await publishFavouriteSaved(email, routeId);
     return { statusCode: 200, body: JSON.stringify({ saved: true }) };
   }
 
@@ -58,6 +63,7 @@ export const handler = async (
       };
     }
     await repository.deleteFavourite(email, routeId);
+    await publishFavouriteDeleted(email, routeId);
     return { statusCode: 200, body: JSON.stringify({ deleted: true }) };
   }
 


### PR DESCRIPTION
## Summary
- send signed AppSync requests from a new helper
- notify AppSync when favourites are added or removed
- expose AppSync URL and credentials to the favourite Lambda
- unit test favourite routes integration

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'jest')*
- `npm run test:unit` *(fails: jest: not found)*
- `cd infrastructure && npm run build` *(fails: Cannot find type definition file for 'jest')*
- `npm run test:unit` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686393f75f00832f8ee61569015675f9