### PR TITLE
Handle missing encodedPolyline in worker routes

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
@@ -145,4 +145,41 @@ describe("worker routes handler", () => {
     expect(mockSave).not.toHaveBeenCalled();
     expect(mockPublish).not.toHaveBeenCalled();
   });
+
+  it("saves route when no encoded polyline is returned", async () => {
+    responseDataHolder.data = JSON.stringify({
+      routes: [
+        {
+          legs: [
+            {
+              distanceMeters: 1500,
+              duration: { seconds: 600 },
+              polyline: {},
+            },
+          ],
+        },
+      ],
+    });
+
+    const handler = loadHandler();
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({
+            routeId: "550e8400-e29b-41d4-a716-446655440001",
+            origin: "a",
+            destination: "b",
+          }),
+        },
+      ],
+    } as any;
+
+    await handler(event);
+
+    const saved = mockSave.mock.calls[0][0];
+    expect(saved.routeId.Value).toBe(
+      "550e8400-e29b-41d4-a716-446655440001"
+    );
+    expect(saved.path).toBeUndefined();
+  });
 });

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -190,11 +190,12 @@ export const handler: SQSHandler = async (event) => {
         ? parseInt(leg.duration.replace(/[^0-9]/g, ""), 10)
         : leg.duration?.seconds ?? 0;
 
+    const encoded = leg.polyline?.encodedPolyline;
     const route = new Route({
       routeId: RouteId.fromString(routeId),
       distanceKm: new DistanceKm((leg.distanceMeters || 0) / 1000),
       duration: new Duration(durationSeconds),
-      path: new Path( leg.polyline?.encodedPolyline ?? "" ),
+      ...(encoded ? { path: new Path(encoded) } : {}),
     });
 
     console.info("💾 Saving route to DynamoDB:", route);


### PR DESCRIPTION
## Summary
- update worker-routes to only build `Path` when the Google API response has `encodedPolyline`
- add a unit test ensuring a route is saved when no encoded polyline is returned

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a3616e30832fbb68bbb8aba82cb6