### PR TITLE
Add maxDeltaKm filtering for route generation

### DIFF
--- a/src/backend/src/routes/interfaces/http/request-routes.test.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.test.ts
@@ -45,4 +45,13 @@ describe("request routes handler", () => {
     expect(JSON.parse(res.body).error).toBeDefined();
     expect(mockSend).not.toHaveBeenCalled();
   });
+
+  it("forwards maxDeltaKm when provided", async () => {
+    mockSend.mockResolvedValueOnce({});
+    await handler({
+      body: JSON.stringify({ maxDeltaKm: 1 }),
+    } as any);
+    const payload = JSON.parse(mockSend.mock.calls[0][0].MessageBody);
+    expect(payload.maxDeltaKm).toBe(1);
+  });
 });

--- a/src/backend/src/routes/interfaces/http/request-routes.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.ts
@@ -21,6 +21,14 @@ export const handler = async (
   if (!data.routeId) {
     data.routeId = RouteId.generate().Value;
   }
+  if (data.maxDeltaKm !== undefined) {
+    const n = Number(data.maxDeltaKm);
+    if (!Number.isNaN(n)) {
+      data.maxDeltaKm = n;
+    } else {
+      delete data.maxDeltaKm;
+    }
+  }
 
   await sqs.send(
     new SendMessageCommand({

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
@@ -234,4 +234,40 @@ describe("worker routes handler", () => {
       { lat: 38.5, lng: -120.2 },
     ]);
   });
+
+  it("skips save when distance difference exceeds maxDeltaKm", async () => {
+    responseDataHolder.data = JSON.stringify({
+      routes: [
+        {
+          legs: [
+            {
+              distanceMeters: 9000,
+              duration: { seconds: 600 },
+              polyline: {},
+            },
+          ],
+        },
+      ],
+    });
+
+    const handler = loadHandler();
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({
+            routeId: "550e8400-e29b-41d4-a716-446655440003",
+            origin: "a",
+            destination: "b",
+            distanceKm: 10,
+            maxDeltaKm: 0.5,
+          }),
+        },
+      ],
+    } as any;
+
+    await handler(event);
+
+    expect(mockSave).not.toHaveBeenCalled();
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- support optional `maxDeltaKm` in request payloads
- forward the value through SQS and check it in worker
- skip saving routes when generated distance deviates too much
- test the new behaviour

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cce19ded4832fbf0befee6d3012b6