### PR TITLE
Add support for multiple route generation

### DIFF
--- a/src/backend/src/routes/interfaces/http/request-routes.test.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.test.ts
@@ -45,4 +45,13 @@ describe("request routes handler", () => {
     expect(JSON.parse(res.body).error).toBeDefined();
     expect(mockSend).not.toHaveBeenCalled();
   });
+
+  it("forwards routesCount when provided", async () => {
+    mockSend.mockResolvedValueOnce({});
+    await handler({
+      body: JSON.stringify({ origin: "A", destination: "B", routesCount: 3 }),
+    } as any);
+    const payload = JSON.parse(mockSend.mock.calls[0][0].MessageBody);
+    expect(payload.routesCount).toBe(3);
+  });
 });

--- a/src/backend/src/routes/interfaces/http/request-routes.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.ts
@@ -21,6 +21,11 @@ export const handler = async (
   if (!data.routeId) {
     data.routeId = RouteId.generate().Value;
   }
+  if (data.routesCount !== undefined) {
+    const num = parseInt(String(data.routesCount), 10);
+    if (!isNaN(num) && num > 0) data.routesCount = num;
+    else delete data.routesCount;
+  }
 
   await sqs.send(
     new SendMessageCommand({

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
@@ -102,7 +102,8 @@ describe("worker routes handler", () => {
     expect(mockSave).toHaveBeenCalledTimes(1);
     const saved = mockSave.mock.calls[0][0];
 
-    expect(saved.routeId.Value).toBe("550e8400-e29b-41d4-a716-446655440000");
+    expect(saved.routeId.Value).toMatch(/^[0-9a-f-]{36}$/);
+    expect(saved.routeId.Value).not.toBe("550e8400-e29b-41d4-a716-446655440000");
     expect(saved.distanceKm.Value).toBe(1.5);
     expect(saved.duration.Value).toBe(600);
     expect(saved.path.Coordinates.map(c => ({ lat: c.Lat, lng: c.Lng }))).toEqual([
@@ -177,7 +178,8 @@ describe("worker routes handler", () => {
     await handler(event);
 
     const saved = mockSave.mock.calls[0][0];
-    expect(saved.routeId.Value).toBe(
+    expect(saved.routeId.Value).toMatch(/^[0-9a-f-]{36}$/);
+    expect(saved.routeId.Value).not.toBe(
       "550e8400-e29b-41d4-a716-446655440001"
     );
     expect(saved.path).toBeUndefined();
@@ -233,5 +235,42 @@ describe("worker routes handler", () => {
       { lat: 40.7, lng: -120.95 },
       { lat: 38.5, lng: -120.2 },
     ]);
+  });
+
+  it("publishes multiple routes when routesCount specified", async () => {
+    responseDataHolder.data = JSON.stringify({
+      routes: [
+        {
+          legs: [
+            {
+              distanceMeters: 1500,
+              duration: { seconds: 600 },
+              polyline: {},
+            },
+          ],
+        },
+      ],
+    });
+
+    const handler = loadHandler();
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({
+            routeId: "550e8400-e29b-41d4-a716-446655440003",
+            origin: "a",
+            distanceKm: 1,
+            routesCount: 2,
+          }),
+        },
+      ],
+    } as any;
+
+    await handler(event);
+
+    expect(mockSave).toHaveBeenCalledTimes(2);
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    const published = mockPublish.mock.calls[0][1];
+    expect(published).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- allow specifying `routesCount` in POST /routes
- generate several routes with random bearings
- publish all generated routes at once
- test that routesCount is forwarded and that multiple routes get published

## Testing
- `tsc --noEmit --project tsconfig.json` *(fails: Cannot find type definition file for 'jest' and 'node')*
- `npm run test:unit --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cce1f7f68832f9614aaa8f0b9d811