### PR TITLE
Enable default generation of three routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # sendeo
+
+`POST /routes` enqueues a job to generate walking routes using the Google Maps
+Directions API. The body can include:
+
+```json
+{
+  "origin": "Address",
+  "destination": "Address",
+  "distanceKm": 5,
+  "routesCount": 3
+}
+```
+
+If `routesCount` is omitted the worker now defaults to generating **three**
+routes instead of one.

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -212,7 +212,7 @@ export const handler: SQSHandler = async (event) => {
       routeId,
       maxDeltaKm,
       routeId: jobId,
-      routesCount = 1,
+      routesCount = 3,
     } = JSON.parse(record.body);
     console.info("➡️ Processing record:", {
       origin,


### PR DESCRIPTION
## Summary
- default the worker to generate 3 routes when none specified
- document how to request multiple routes via `POST /routes`

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce00bc8bc832fb854b849545e621a