### PR TITLE
Fix job route association

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -245,6 +245,7 @@ export const handler: SQSHandler = async (event) => {
 
         const route = new Route({
           routeId: UUID.generate(),
+          jobId: UUID.fromString(jobId),
           distanceKm: new DistanceKm(leg.distanceMeters / 1000),
           duration: new Duration(leg.durationSeconds),
           ...(leg.encoded ? { path: new Path(leg.encoded) } : {}),
@@ -318,6 +319,7 @@ export const handler: SQSHandler = async (event) => {
 
       const route = new Route({
         routeId: UUID.generate(),
+        jobId: UUID.fromString(jobId),
         distanceKm: new DistanceKm(totalDistance / 1000),
         duration: new Duration(totalDuration),
         ...(encoded ? { path: new Path(encoded) } : {}),


### PR DESCRIPTION
## Summary
- store the provided `jobId` when saving routes generated by the SQS worker

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d18a901f8832fbbc476e097c59b52