### PR TITLE
Update DynamoDB policy for PageRouter

### DIFF
--- a/infrastructure/lib/stacks/compute-stack.test.ts
+++ b/infrastructure/lib/stacks/compute-stack.test.ts
@@ -1,5 +1,5 @@
 import * as cdk from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
+import { Template, Match } from "aws-cdk-lib/assertions";
 import { ComputeStack } from "./compute-stack";
 import { Table, AttributeType, BillingMode } from "aws-cdk-lib/aws-dynamodb";
 import { Queue } from "aws-cdk-lib/aws-sqs";
@@ -55,5 +55,27 @@ describe("ComputeStack", () => {
 
   test("creates two SQS event source mappings", () => {
     template.resourceCountIs("AWS::Lambda::EventSourceMapping", 2);
+  });
+
+  test("grants PageRouter access to the GSI2 index", () => {
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Resource: Match.arrayWith([
+              Match.objectLike({
+                "Fn::Join": Match.arrayWith([
+                  "",
+                  Match.arrayWith([
+                    Match.objectLike({ "Fn::GetAtt": Match.arrayWith([Match.stringLikeRegexp("Routes"), "Arn"]) }),
+                    "/index/*",
+                  ]),
+                ]),
+              }),
+            ]),
+          }),
+        ]),
+      },
+    });
   });
 });

--- a/infrastructure/lib/stacks/compute-stack.ts
+++ b/infrastructure/lib/stacks/compute-stack.ts
@@ -141,7 +141,10 @@ export class ComputeStack extends cdk.Stack {
     pageRouter.fn.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ["dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan"],
-        resources: [props.routesTable.tableArn],
+        resources: [
+          props.routesTable.tableArn,
+          `${props.routesTable.tableArn}/index/*`,
+        ],
       })
     );
     pageRouter.fn.addToRolePolicy(


### PR DESCRIPTION
## Summary
- allow PageRouter Lambda to read DynamoDB GSI2 index
- test that the IAM policy includes the index resource

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d275379dc832fb0c4af1a035933a3