### PR TITLE
Increase worker timeout

### DIFF
--- a/infrastructure/lib/constructs/sqs-consumer.ts
+++ b/infrastructure/lib/constructs/sqs-consumer.ts
@@ -1,4 +1,5 @@
 import { Construct } from 'constructs';
+import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as path from 'path';
@@ -10,6 +11,10 @@ export interface SqsConsumerProps {
   readonly handler: string;
   readonly environment?: { [k: string]: string };
   readonly queue: sqs.IQueue;
+  /** Optional memory size for the Lambda function in MB */
+  readonly memorySize?: number;
+  /** Optional timeout for the Lambda function */
+  readonly timeout?: cdk.Duration;
 }
 
 export class SqsConsumer extends Construct {
@@ -24,6 +29,8 @@ export class SqsConsumer extends Construct {
       entry: path.join(props.entry, `${file}.ts`),
       handler: fnName,
       environment: props.environment,
+      ...(props.memorySize ? { memorySize: props.memorySize } : {}),
+      ...(props.timeout ? { timeout: props.timeout } : {}),
     });
 
     this.fn.addEventSource(new SqsEventSource(props.queue));

--- a/infrastructure/lib/stacks/compute-stack.ts
+++ b/infrastructure/lib/stacks/compute-stack.ts
@@ -67,6 +67,8 @@ export class ComputeStack extends cdk.Stack {
       ),
       handler: "worker-routes.handler",
       queue: props.routeJobsQueue,
+      memorySize: 1024,
+      timeout: cdk.Duration.seconds(30),
       environment: {
         ROUTES_TABLE: props.routesTable.tableName,
         ...(props.appSyncUrl ? { APPSYNC_URL: props.appSyncUrl } : {}),


### PR DESCRIPTION
## Summary
- allow customizing Lambda memory & timeout for SQS consumers
- bump `WorkerRoutes` lambda to 30 seconds and 1GB

## Testing
- `npm run --silent test:unit --prefix infrastructure` *(fails: jest not found)*
- `npm run --silent test:unit --prefix src/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d37e5a510832fb5b7fca594200572