### PR TITLE
Add profile endpoints

### DIFF
--- a/src/backend/src/routes/application/use-cases/add-favourite.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/add-favourite.usecase.test.ts
@@ -9,6 +9,8 @@ describe('AddFavouriteUseCase', () => {
       getFavourites: jest.fn().mockResolvedValue([]),
       putFavourite: jest.fn(),
       deleteFavourite: jest.fn(),
+      getProfile: jest.fn(),
+      putProfile: jest.fn(),
     } as any;
     const useCase = new AddFavouriteUseCase(repo);
     await useCase.execute(email, routeId);
@@ -21,6 +23,8 @@ describe('AddFavouriteUseCase', () => {
       getFavourites: jest.fn().mockResolvedValue(['FAV#1']),
       putFavourite: jest.fn(),
       deleteFavourite: jest.fn(),
+      getProfile: jest.fn(),
+      putProfile: jest.fn(),
     } as any;
     const useCase = new AddFavouriteUseCase(repo);
     await expect(useCase.execute(email, routeId)).rejects.toBeInstanceOf(FavouriteAlreadyExistsError);

--- a/src/backend/src/routes/application/use-cases/remove-favourite.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/remove-favourite.usecase.test.ts
@@ -7,6 +7,8 @@ describe('RemoveFavouriteUseCase', () => {
       deleteFavourite: jest.fn(),
       putFavourite: jest.fn(),
       getFavourites: jest.fn(),
+      getProfile: jest.fn(),
+      putProfile: jest.fn(),
     } as any;
     const useCase = new RemoveFavouriteUseCase(repo);
     await useCase.execute('user@example.com', '1');

--- a/src/backend/src/routes/domain/entities/user-profile.ts
+++ b/src/backend/src/routes/domain/entities/user-profile.ts
@@ -1,0 +1,8 @@
+export interface UserProfile {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  displayName?: string;
+  age?: number;
+  unit?: string;
+}

--- a/src/backend/src/routes/domain/repositories/user-state-repository.ts
+++ b/src/backend/src/routes/domain/repositories/user-state-repository.ts
@@ -1,5 +1,8 @@
+import { UserProfile } from '../entities/user-profile';
+
 export interface UserStateRepository {
   putFavourite(email: string, routeId: string): Promise<void>;
   deleteFavourite(email: string, routeId: string): Promise<void>;
   getFavourites(user: string): Promise<string[]>;
-}
+  getProfile(email: string): Promise<UserProfile | null>;
+  putProfile(profile: UserProfile): Promise<void>;}

--- a/src/backend/src/routes/infrastructure/dynamodb/dynamo-user-state-repository.test.ts
+++ b/src/backend/src/routes/infrastructure/dynamodb/dynamo-user-state-repository.test.ts
@@ -3,6 +3,7 @@ import {
   PutItemCommand,
   DeleteItemCommand,
   QueryCommand,
+  GetItemCommand,
 } from "@aws-sdk/client-dynamodb";
 import { DynamoUserStateRepository } from "./dynamo-user-state-repository";
 
@@ -69,5 +70,69 @@ describe("DynamoUserStateRepository", () => {
     const result = await repo.getFavourites(email);
     expect(mockSend).toHaveBeenCalled();
     expect(result).toEqual([]);
+  });
+
+  it("putProfile sends a PutItemCommand with correct params", async () => {
+    const profile = {
+      email,
+      firstName: "Test",
+      lastName: "User",
+      displayName: "TU",
+      age: 30,
+      unit: "km",
+    };
+    await repo.putProfile(profile);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const cmd = mockSend.mock.calls[0][0];
+    expect(cmd).toBeInstanceOf(PutItemCommand);
+    expect((cmd as any).input).toEqual({
+      TableName: tableName,
+      Item: {
+        PK: { S: `USER#${email}` },
+        SK: { S: "PROFILE" },
+        email: { S: email },
+        firstName: { S: "Test" },
+        lastName: { S: "User" },
+        displayName: { S: "TU" },
+        age: { N: "30" },
+        unit: { S: "km" },
+      },
+    });
+  });
+
+  it("getProfile returns parsed profile", async () => {
+    mockSend.mockResolvedValueOnce({
+      Item: {
+        email: { S: email },
+        firstName: { S: "Test" },
+        lastName: { S: "User" },
+        displayName: { S: "TU" },
+        age: { N: "40" },
+        unit: { S: "mi" },
+      },
+    });
+    const result = await repo.getProfile(email);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const cmd = mockSend.mock.calls[0][0];
+    expect(cmd).toBeInstanceOf(GetItemCommand);
+    expect((cmd as any).input).toEqual({
+      TableName: tableName,
+      Key: { PK: { S: `USER#${email}` }, SK: { S: "PROFILE" } },
+    });
+    expect(result).toEqual({
+      email,
+      firstName: "Test",
+      lastName: "User",
+      displayName: "TU",
+      age: 40,
+      unit: "mi",
+    });
+  });
+
+  it("getProfile returns null when no item", async () => {
+    mockSend.mockResolvedValueOnce({});
+    const result = await repo.getProfile(email);
+    expect(mockSend).toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 });

--- a/src/backend/src/routes/infrastructure/dynamodb/dynamo-user-state-repository.ts
+++ b/src/backend/src/routes/infrastructure/dynamodb/dynamo-user-state-repository.ts
@@ -3,8 +3,10 @@ import {
   PutItemCommand,
   DeleteItemCommand,
   QueryCommand,
+  GetItemCommand,
 } from "@aws-sdk/client-dynamodb";
 import { UserStateRepository } from "../../domain/repositories/user-state-repository";
+import { UserProfile } from "../../domain/entities/user-profile";
 
 export class DynamoUserStateRepository implements UserStateRepository {
   constructor(private client: DynamoDBClient, private tableName: string) {}
@@ -44,5 +46,40 @@ export class DynamoUserStateRepository implements UserStateRepository {
       })
     );
     return (res.Items || []).map((i) => i.SK.S!);
+  }
+
+  async getProfile(email: string): Promise<UserProfile | null> {
+    const res = await this.client.send(
+      new GetItemCommand({
+        TableName: this.tableName,
+        Key: { PK: { S: `USER#${email}` }, SK: { S: "PROFILE" } },
+      })
+    );
+    if (!res.Item) return null;
+    return {
+      email: res.Item.email?.S ?? email,
+      firstName: res.Item.firstName?.S,
+      lastName: res.Item.lastName?.S,
+      displayName: res.Item.displayName?.S,
+      age: res.Item.age ? parseInt(res.Item.age.N!, 10) : undefined,
+      unit: res.Item.unit?.S,
+    };
+  }
+
+  async putProfile(profile: UserProfile): Promise<void> {
+    const item: any = {
+      PK: { S: `USER#${profile.email}` },
+      SK: { S: "PROFILE" },
+      email: { S: profile.email },
+    };
+    if (profile.firstName != null) item.firstName = { S: profile.firstName };
+    if (profile.lastName != null) item.lastName = { S: profile.lastName };
+    if (profile.displayName != null)
+      item.displayName = { S: profile.displayName };
+    if (profile.age != null) item.age = { N: profile.age.toString() };
+    if (profile.unit != null) item.unit = { S: profile.unit };
+    await this.client.send(
+      new PutItemCommand({ TableName: this.tableName, Item: item })
+    );
   }
 }

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -108,11 +108,32 @@ export const handler = async (
   }
 
   if (resource === "/profile" && httpMethod === "GET") {
-    return { statusCode: 200, body: JSON.stringify({ ok: true }) };
+    const profile = await userStateRepository.getProfile(email);
+    if (!profile) {
+      return { statusCode: 404, body: JSON.stringify({ error: "Not Found" }) };
+    }
+    return { statusCode: 200, body: JSON.stringify(profile) };
   }
 
   if (resource === "/profile" && httpMethod === "PUT") {
-    return { statusCode: 200, body: JSON.stringify({ ok: true }) };
+    let payload: any = {};
+    if (event.body) {
+      try {
+        payload = JSON.parse(event.body);
+      } catch {
+        return { statusCode: 400, body: JSON.stringify({ error: "Invalid JSON body" }) };
+      }
+    }
+    const profile = {
+      email,
+      firstName: payload.firstName,
+      lastName: payload.lastName,
+      displayName: payload.displayName,
+      age: payload.age != null ? Number(payload.age) : undefined,
+      unit: payload.unit,
+    };
+    await userStateRepository.putProfile(profile);
+    return { statusCode: 200, body: JSON.stringify({ updated: true }) };
   }
 
   if (httpMethod === "GET" && resource === "/favourites") {


### PR DESCRIPTION
## Summary
- implement user profile entity
- extend user state repository with profile methods
- support /profile GET and PUT in page router
- update tests for new behaviour

## Testing
- `npm --prefix src/backend run test:unit` *(fails: jest not found)*
- `npm --prefix src/backend run build` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686d488b652c832fb93e30d8da62292a