### PR TITLE
Add AppSync notifications for telemetry

### DIFF
--- a/infrastructure/lib/stacks/compute-stack.ts
+++ b/infrastructure/lib/stacks/compute-stack.ts
@@ -128,6 +128,9 @@ export class ComputeStack extends cdk.Stack {
         ROUTES_TABLE: props.routesTable.tableName,
         USER_STATE_TABLE: props.userStateTable.tableName,
         METRICS_QUEUE: props.metricsQueue.queueUrl,
+        ...(props.appSyncUrl ? { APPSYNC_URL: props.appSyncUrl } : {}),
+        ...(props.appSyncApiKey ? { APPSYNC_API_KEY: props.appSyncApiKey } : {}),
+        ...(props.appSyncRegion ? { APPSYNC_REGION: props.appSyncRegion } : {}),
       },
       api,
       routes: [
@@ -156,6 +159,9 @@ export class ComputeStack extends cdk.Stack {
       })
     );
     props.metricsQueue.grantSendMessages(pageRouter.fn);
+    pageRouter.fn.addToRolePolicy(
+      new iam.PolicyStatement({ actions: ["appsync:GraphQL"], resources: ["*"] })
+    );
 
     // 5) MetricsConsumer
     new SqsConsumer(this, "MetricsConsumer", {

--- a/src/backend/src/routes/interfaces/appsync-client.ts
+++ b/src/backend/src/routes/interfaces/appsync-client.ts
@@ -74,3 +74,21 @@ export async function publishRoutesGenerated(jobId: string, routes: Route[]) {
     { jobId, routes: inputs }
   );
 }
+
+export async function publishRouteStarted(email: string, routeId: string) {
+  await send(
+    `mutation PublishRouteStarted($email: String!, $routeId: ID!) {\n  publishRouteStarted(email: $email, routeId: $routeId)\n}`,
+    { email, routeId }
+  );
+}
+
+export async function publishRouteFinished(
+  email: string,
+  routeId: string,
+  summary: string
+) {
+  await send(
+    `mutation PublishRouteFinished($email: String!, $routeId: ID!, $summary: String!) {\n  publishRouteFinished(email: $email, routeId: $routeId, summary: $summary)\n}`,
+    { email, routeId, summary }
+  );
+}


### PR DESCRIPTION
## Summary
- send route start/finish events to AppSync
- expose AppSync environment variables to PageRouter
- expect AppSync calls in page router tests

## Testing
- `npm run test:unit --prefix src/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3426d318832fa4b74732551a9e40