### PR TITLE
Implement Email value object and user profile entity

### DIFF
--- a/src/backend/src/routes/application/use-cases/get-user-profile.ts
+++ b/src/backend/src/routes/application/use-cases/get-user-profile.ts
@@ -1,0 +1,16 @@
+import { UserStateRepository } from '../..//domain/repositories/user-state-repository';
+import { UserProfile } from '../..//domain/entities/user-profile';
+import { Email } from '../..//domain/value-objects/email-value-object';
+
+export class GetUserProfileUseCase {
+  constructor(private repository: UserStateRepository) {}
+
+  async execute(email: Email): Promise<UserProfile> {
+    let profile = await this.repository.getProfile(email);
+    if (!profile) {
+      profile = UserProfile.fromPrimitives({ email: email.Value });
+      await this.repository.putProfile(profile);
+    }
+    return profile;
+  }
+}

--- a/src/backend/src/routes/application/use-cases/get-user-profile.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/get-user-profile.usecase.test.ts
@@ -1,0 +1,21 @@
+import { GetUserProfileUseCase } from './get-user-profile';
+import { UserStateRepository } from '../../domain/repositories/user-state-repository';
+import { UserProfile } from '../../domain/entities/user-profile';
+import { Email } from '../../domain/value-objects/email-value-object';
+
+describe('GetUserProfileUseCase', () => {
+  it('creates profile when missing', async () => {
+    const repo: UserStateRepository = {
+      getProfile: jest.fn().mockResolvedValue(null),
+      putProfile: jest.fn(),
+      putFavourite: jest.fn(),
+      deleteFavourite: jest.fn(),
+      getFavourites: jest.fn(),
+    } as any;
+    const useCase = new GetUserProfileUseCase(repo);
+    const email = Email.fromString('u@e.com');
+    const res = await useCase.execute(email);
+    expect(repo.putProfile).toHaveBeenCalled();
+    expect(res.email.Value).toBe('u@e.com');
+  });
+});

--- a/src/backend/src/routes/application/use-cases/update-user-profile.ts
+++ b/src/backend/src/routes/application/use-cases/update-user-profile.ts
@@ -1,0 +1,10 @@
+import { UserStateRepository } from '../..//domain/repositories/user-state-repository';
+import { UserProfile } from '../..//domain/entities/user-profile';
+
+export class UpdateUserProfileUseCase {
+  constructor(private repository: UserStateRepository) {}
+
+  async execute(profile: UserProfile): Promise<void> {
+    await this.repository.putProfile(profile);
+  }
+}

--- a/src/backend/src/routes/application/use-cases/update-user-profile.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/update-user-profile.usecase.test.ts
@@ -1,0 +1,20 @@
+import { UpdateUserProfileUseCase } from './update-user-profile';
+import { UserStateRepository } from '../../domain/repositories/user-state-repository';
+import { UserProfile } from '../../domain/entities/user-profile';
+import { Email } from '../../domain/value-objects/email-value-object';
+
+describe('UpdateUserProfileUseCase', () => {
+  it('calls repository with provided profile', async () => {
+    const repo: UserStateRepository = {
+      putProfile: jest.fn(),
+      getProfile: jest.fn(),
+      putFavourite: jest.fn(),
+      deleteFavourite: jest.fn(),
+      getFavourites: jest.fn(),
+    } as any;
+    const useCase = new UpdateUserProfileUseCase(repo);
+    const profile = UserProfile.fromPrimitives({ email: 'a@b.com' });
+    await useCase.execute(profile);
+    expect(repo.putProfile).toHaveBeenCalledWith(profile);
+  });
+});

--- a/src/backend/src/routes/domain/entities/user-profile.test.ts
+++ b/src/backend/src/routes/domain/entities/user-profile.test.ts
@@ -1,0 +1,22 @@
+import { UserProfile } from './user-profile';
+import { Email } from '../value-objects/email-value-object';
+import { Age } from '../value-objects/age-value-object';
+import { DistanceUnit } from '../value-objects/distance-unit-value-object';
+
+describe('UserProfile', () => {
+  it('converts to and from primitives', () => {
+    const profile = UserProfile.fromPrimitives({
+      email: 'a@b.com',
+      firstName: 'A',
+      lastName: 'B',
+      displayName: 'AB',
+      age: 20,
+      unit: 'km',
+    });
+    const roundtrip = UserProfile.fromPrimitives(profile.toPrimitives());
+    expect(roundtrip.email.Value).toBe('a@b.com');
+    expect(roundtrip.firstName).toBe('A');
+    expect(roundtrip.age?.Value).toBe(20);
+    expect(roundtrip.unit?.Value).toBe('km');
+  });
+});

--- a/src/backend/src/routes/domain/entities/user-profile.ts
+++ b/src/backend/src/routes/domain/entities/user-profile.ts
@@ -1,8 +1,75 @@
-export interface UserProfile {
-  email: string;
+import { Email } from '../value-objects/email-value-object';
+import { Age } from '../value-objects/age-value-object';
+import { DistanceUnit } from '../value-objects/distance-unit-value-object';
+
+export interface UserProfileProps {
+  email: Email;
   firstName?: string;
   lastName?: string;
   displayName?: string;
-  age?: number;
-  unit?: string;
+  age?: Age;
+  unit?: DistanceUnit;
+}
+
+export class UserProfile {
+  private constructor(private props: UserProfileProps) {}
+
+  static create(props: UserProfileProps): UserProfile {
+    return new UserProfile(props);
+  }
+
+  static fromPrimitives(obj: {
+    email: string;
+    firstName?: string;
+    lastName?: string;
+    displayName?: string;
+    age?: number;
+    unit?: string;
+  }): UserProfile {
+    return new UserProfile({
+      email: Email.fromString(obj.email),
+      firstName: obj.firstName,
+      lastName: obj.lastName,
+      displayName: obj.displayName,
+      age: obj.age != null ? Age.fromNumber(obj.age) : undefined,
+      unit: obj.unit != null ? DistanceUnit.fromString(obj.unit) : undefined,
+    });
+  }
+
+  toPrimitives(): {
+    email: string;
+    firstName?: string;
+    lastName?: string;
+    displayName?: string;
+    age?: number;
+    unit?: string;
+  } {
+    return {
+      email: this.props.email.Value,
+      firstName: this.props.firstName,
+      lastName: this.props.lastName,
+      displayName: this.props.displayName,
+      age: this.props.age?.Value,
+      unit: this.props.unit?.Value,
+    };
+  }
+
+  get email(): Email {
+    return this.props.email;
+  }
+  get firstName(): string | undefined {
+    return this.props.firstName;
+  }
+  get lastName(): string | undefined {
+    return this.props.lastName;
+  }
+  get displayName(): string | undefined {
+    return this.props.displayName;
+  }
+  get age(): Age | undefined {
+    return this.props.age;
+  }
+  get unit(): DistanceUnit | undefined {
+    return this.props.unit;
+  }
 }

--- a/src/backend/src/routes/domain/repositories/user-state-repository.ts
+++ b/src/backend/src/routes/domain/repositories/user-state-repository.ts
@@ -1,8 +1,9 @@
 import { UserProfile } from '../entities/user-profile';
+import { Email } from '../value-objects/email-value-object';
 
 export interface UserStateRepository {
   putFavourite(email: string, routeId: string): Promise<void>;
   deleteFavourite(email: string, routeId: string): Promise<void>;
-  getFavourites(user: string): Promise<string[]>;
-  getProfile(email: string): Promise<UserProfile | null>;
-  putProfile(profile: UserProfile): Promise<void>;}
+  getFavourites(user: string): Promise<string[]>;  getProfile(email: Email): Promise<UserProfile | null>;
+  putProfile(profile: UserProfile): Promise<void>;
+}

--- a/src/backend/src/routes/domain/value-objects/age-value-object.test.ts
+++ b/src/backend/src/routes/domain/value-objects/age-value-object.test.ts
@@ -1,0 +1,15 @@
+import { Age } from './age-value-object';
+
+describe('Age', () => {
+  it('creates from valid number', () => {
+    expect(Age.fromNumber(30).Value).toBe(30);
+  });
+
+  it('throws for negative', () => {
+    expect(() => Age.fromNumber(-1)).toThrow('Invalid age');
+  });
+
+  it('throws for too high', () => {
+    expect(() => Age.fromNumber(200)).toThrow('Invalid age');
+  });
+});

--- a/src/backend/src/routes/domain/value-objects/age-value-object.ts
+++ b/src/backend/src/routes/domain/value-objects/age-value-object.ts
@@ -1,0 +1,15 @@
+export class Age {
+  private constructor(private readonly value: number) {
+    if (!Number.isInteger(value) || value < 0 || value > 120) {
+      throw new Error('Invalid age');
+    }
+  }
+
+  static fromNumber(value: number): Age {
+    return new Age(value);
+  }
+
+  get Value(): number {
+    return this.value;
+  }
+}

--- a/src/backend/src/routes/domain/value-objects/distance-unit-value-object.test.ts
+++ b/src/backend/src/routes/domain/value-objects/distance-unit-value-object.test.ts
@@ -1,0 +1,12 @@
+import { DistanceUnit } from './distance-unit-value-object';
+
+describe('DistanceUnit', () => {
+  it('creates from valid unit', () => {
+    expect(DistanceUnit.fromString('km').Value).toBe('km');
+    expect(DistanceUnit.fromString('mi').Value).toBe('mi');
+  });
+
+  it('throws for invalid unit', () => {
+    expect(() => DistanceUnit.fromString('m')).toThrow('Invalid distance unit');
+  });
+});

--- a/src/backend/src/routes/domain/value-objects/distance-unit-value-object.ts
+++ b/src/backend/src/routes/domain/value-objects/distance-unit-value-object.ts
@@ -1,0 +1,16 @@
+export type DistanceUnitType = 'km' | 'mi';
+
+export class DistanceUnit {
+  private constructor(private readonly value: DistanceUnitType) {}
+
+  static fromString(value: string): DistanceUnit {
+    if (value !== 'km' && value !== 'mi') {
+      throw new Error('Invalid distance unit');
+    }
+    return new DistanceUnit(value as DistanceUnitType);
+  }
+
+  get Value(): DistanceUnitType {
+    return this.value;
+  }
+}

--- a/src/backend/src/routes/domain/value-objects/email-value-object.test.ts
+++ b/src/backend/src/routes/domain/value-objects/email-value-object.test.ts
@@ -1,0 +1,12 @@
+import { Email } from './email-value-object';
+
+describe('Email', () => {
+  it('creates from valid string', () => {
+    const e = Email.fromString('user@example.com');
+    expect(e.Value).toBe('user@example.com');
+  });
+
+  it('throws on invalid email', () => {
+    expect(() => Email.fromString('bad')).toThrow('Invalid email address');
+  });
+});

--- a/src/backend/src/routes/domain/value-objects/email-value-object.ts
+++ b/src/backend/src/routes/domain/value-objects/email-value-object.ts
@@ -1,0 +1,20 @@
+export class Email {
+  private constructor(private readonly value: string) {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(value)) {
+      throw new Error('Invalid email address');
+    }
+  }
+
+  static fromString(value: string): Email {
+    return new Email(value);
+  }
+
+  get Value(): string {
+    return this.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/src/backend/src/routes/infrastructure/dynamodb/dynamo-user-state-repository.test.ts
+++ b/src/backend/src/routes/infrastructure/dynamodb/dynamo-user-state-repository.test.ts
@@ -4,15 +4,17 @@ import {
   DeleteItemCommand,
   QueryCommand,
   GetItemCommand,
-} from "@aws-sdk/client-dynamodb";
-import { DynamoUserStateRepository } from "./dynamo-user-state-repository";
+} from '@aws-sdk/client-dynamodb';
+import { DynamoUserStateRepository } from './dynamo-user-state-repository';
+import { UserProfile } from '../../domain/entities/user-profile';
+import { Email } from '../../domain/value-objects/email-value-object';
 
-describe("DynamoUserStateRepository", () => {
+describe('DynamoUserStateRepository', () => {
   let mockSend: jest.Mock;
   let repo: DynamoUserStateRepository;
-  const tableName = "UserState";
-  const email = "test@example.com";
-  const routeId = "123";
+  const tableName = 'UserState';
+  const email = Email.fromString('test@example.com');
+  const routeId = '123';
 
   beforeEach(() => {
     mockSend = jest.fn();
@@ -20,67 +22,67 @@ describe("DynamoUserStateRepository", () => {
     repo = new DynamoUserStateRepository(client, tableName);
   });
 
-  it("putFavourite sends a PutItemCommand with correct params", async () => {
-    await repo.putFavourite(email, routeId);
+  it('putFavourite sends a PutItemCommand with correct params', async () => {
+    await repo.putFavourite(email.Value, routeId);
     expect(mockSend).toHaveBeenCalledTimes(1);
     const cmd = mockSend.mock.calls[0][0];
     expect(cmd).toBeInstanceOf(PutItemCommand);
     expect((cmd as any).input).toEqual({
       TableName: tableName,
       Item: {
-        PK: { S: `USER#${email}` },
+        PK: { S: `USER#${email.Value}` },
         SK: { S: `FAV#${routeId}` },
       },
     });
   });
 
-  it("deleteFavourite sends a DeleteItemCommand with correct params", async () => {
-    await repo.deleteFavourite(email, routeId);
+  it('deleteFavourite sends a DeleteItemCommand with correct params', async () => {
+    await repo.deleteFavourite(email.Value, routeId);
     expect(mockSend).toHaveBeenCalledTimes(1);
     const cmd = mockSend.mock.calls[0][0];
     expect(cmd).toBeInstanceOf(DeleteItemCommand);
     expect((cmd as any).input).toEqual({
       TableName: tableName,
       Key: {
-        PK: { S: `USER#${email}` },
+        PK: { S: `USER#${email.Value}` },
         SK: { S: `FAV#${routeId}` },
       },
     });
   });
 
-  it("getFavourites returns SK values from QueryCommand results", async () => {
-    const items = [{ SK: { S: "FAV#1" } }, { SK: { S: "FAV#2" } }];
+  it('getFavourites returns SK values from QueryCommand results', async () => {
+    const items = [{ SK: { S: 'FAV#1' } }, { SK: { S: 'FAV#2' } }];
     mockSend.mockResolvedValueOnce({ Items: items });
-    const result = await repo.getFavourites(email);
+    const result = await repo.getFavourites(email.Value);
 
     expect(mockSend).toHaveBeenCalledTimes(1);
     const cmd = mockSend.mock.calls[0][0];
     expect(cmd).toBeInstanceOf(QueryCommand);
     expect((cmd as any).input).toEqual({
       TableName: tableName,
-      KeyConditionExpression: "PK = :pk",
-      ExpressionAttributeValues: { ":pk": { S: `USER#${email}` } },
+      KeyConditionExpression: 'PK = :pk',
+      ExpressionAttributeValues: { ':pk': { S: `USER#${email.Value}` } },
     });
 
-    expect(result).toEqual(["FAV#1", "FAV#2"]);
+    expect(result).toEqual(['FAV#1', 'FAV#2']);
   });
 
-  it("getFavourites returns empty array if no items", async () => {
+  it('getFavourites returns empty array if no items', async () => {
     mockSend.mockResolvedValueOnce({});
-    const result = await repo.getFavourites(email);
+    const result = await repo.getFavourites(email.Value);
     expect(mockSend).toHaveBeenCalled();
     expect(result).toEqual([]);
   });
 
-  it("putProfile sends a PutItemCommand with correct params", async () => {
-    const profile = {
-      email,
-      firstName: "Test",
-      lastName: "User",
-      displayName: "TU",
+  it('putProfile sends a PutItemCommand with correct params', async () => {
+    const profile = UserProfile.fromPrimitives({
+      email: email.Value,
+      firstName: 'Test',
+      lastName: 'User',
+      displayName: 'TU',
       age: 30,
-      unit: "km",
-    };
+      unit: 'km',
+    });
     await repo.putProfile(profile);
     expect(mockSend).toHaveBeenCalledTimes(1);
     const cmd = mockSend.mock.calls[0][0];
@@ -88,27 +90,27 @@ describe("DynamoUserStateRepository", () => {
     expect((cmd as any).input).toEqual({
       TableName: tableName,
       Item: {
-        PK: { S: `USER#${email}` },
-        SK: { S: "PROFILE" },
-        email: { S: email },
-        firstName: { S: "Test" },
-        lastName: { S: "User" },
-        displayName: { S: "TU" },
-        age: { N: "30" },
-        unit: { S: "km" },
+        PK: { S: `USER#${email.Value}` },
+        SK: { S: 'PROFILE' },
+        email: { S: email.Value },
+        firstName: { S: 'Test' },
+        lastName: { S: 'User' },
+        displayName: { S: 'TU' },
+        age: { N: '30' },
+        unit: { S: 'km' },
       },
     });
   });
 
-  it("getProfile returns parsed profile", async () => {
+  it('getProfile returns parsed profile', async () => {
     mockSend.mockResolvedValueOnce({
       Item: {
-        email: { S: email },
-        firstName: { S: "Test" },
-        lastName: { S: "User" },
-        displayName: { S: "TU" },
-        age: { N: "40" },
-        unit: { S: "mi" },
+        email: { S: email.Value },
+        firstName: { S: 'Test' },
+        lastName: { S: 'User' },
+        displayName: { S: 'TU' },
+        age: { N: '40' },
+        unit: { S: 'mi' },
       },
     });
     const result = await repo.getProfile(email);
@@ -117,19 +119,19 @@ describe("DynamoUserStateRepository", () => {
     expect(cmd).toBeInstanceOf(GetItemCommand);
     expect((cmd as any).input).toEqual({
       TableName: tableName,
-      Key: { PK: { S: `USER#${email}` }, SK: { S: "PROFILE" } },
+      Key: { PK: { S: `USER#${email.Value}` }, SK: { S: 'PROFILE' } },
     });
-    expect(result).toEqual({
-      email,
-      firstName: "Test",
-      lastName: "User",
-      displayName: "TU",
+    expect(result?.toPrimitives()).toEqual({
+      email: email.Value,
+      firstName: 'Test',
+      lastName: 'User',
+      displayName: 'TU',
       age: 40,
-      unit: "mi",
+      unit: 'mi',
     });
   });
 
-  it("getProfile returns null when no item", async () => {
+  it('getProfile returns null when no item', async () => {
     mockSend.mockResolvedValueOnce({});
     const result = await repo.getProfile(email);
     expect(mockSend).toHaveBeenCalled();

--- a/src/backend/src/routes/interfaces/http/page-router.test.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.test.ts
@@ -48,6 +48,8 @@ import { DistanceKm } from "../../domain/value-objects/distance-value-object";
 import { Duration } from "../../domain/value-objects/duration-value-object";
 import { Path } from "../../domain/value-objects/path-value-object";
 import { LatLng } from "../../domain/value-objects/lat-lng-value-object";
+import { UserProfile } from "../../domain/entities/user-profile";
+import { Email } from "../../domain/value-objects/email-value-object";
 
 const baseCtx = {
   requestContext: {
@@ -233,19 +235,19 @@ describe("page router profile", () => {
   } as any;
 
   it("returns profile on GET", async () => {
-    const profile = { email: "test@example.com", firstName: "t" };
+    const profile = UserProfile.fromPrimitives({ email: "test@example.com", firstName: "t" });
     mockGetProfile.mockResolvedValueOnce(profile);
     const res = await handler({ ...baseEvent, httpMethod: "GET" });
-    expect(mockGetProfile).toHaveBeenCalledWith("test@example.com");
+    expect(mockGetProfile).toHaveBeenCalledWith(expect.any(Email));
     expect(mockPutProfile).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual(profile);
+    expect(JSON.parse(res.body)).toEqual(profile.toPrimitives());
   });
 
   it("creates profile when missing", async () => {
     mockGetProfile.mockResolvedValueOnce(null);
     const res = await handler({ ...baseEvent, httpMethod: "GET" });
-    expect(mockPutProfile).toHaveBeenCalledWith({ email: "test@example.com" });
+    expect(mockPutProfile).toHaveBeenCalled();
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ email: "test@example.com" });
   });
@@ -257,14 +259,7 @@ describe("page router profile", () => {
       httpMethod: "PUT",
       body: JSON.stringify(body),
     });
-    expect(mockPutProfile).toHaveBeenCalledWith({
-      email: "test@example.com",
-      firstName: "A",
-      lastName: "B",
-      displayName: undefined,
-      age: undefined,
-      unit: undefined,
-    });
+    expect(mockPutProfile).toHaveBeenCalledWith(expect.any(UserProfile));
     expect(res.statusCode).toBe(200);
   });
 

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -10,6 +10,10 @@ import {
 import { UUID } from "../../domain/value-objects/uuid-value-object";
 import { ListRoutesUseCase } from "../../application/use-cases/list-routes";
 import { GetRouteDetailsUseCase } from "../../application/use-cases/get-route-details";
+import { GetUserProfileUseCase } from "../../application/use-cases/get-user-profile";
+import { UpdateUserProfileUseCase } from "../../application/use-cases/update-user-profile";
+import { Email } from "../../domain/value-objects/email-value-object";
+import { UserProfile } from "../../domain/entities/user-profile";
 
 const dynamo = new DynamoDBClient({});
 const sqs = new SQSClient({});
@@ -23,6 +27,8 @@ const userStateRepository = new DynamoUserStateRepository(
 );
 const listRoutes = new ListRoutesUseCase(routeRepository);
 const getRouteDetails = new GetRouteDetailsUseCase(routeRepository);
+const getUserProfile = new GetUserProfileUseCase(userStateRepository);
+const updateUserProfile = new UpdateUserProfileUseCase(userStateRepository);
 
 export const handler = async (
   event: APIGatewayProxyEvent
@@ -114,12 +120,8 @@ export const handler = async (
   }
 
   if (resource === "/profile" && httpMethod === "GET") {
-    let profile = await userStateRepository.getProfile(email);
-    if (!profile) {
-      profile = { email };
-      await userStateRepository.putProfile(profile);
-    }
-    return { statusCode: 200, body: JSON.stringify(profile) };
+    const profile = await getUserProfile.execute(Email.fromString(email));
+    return { statusCode: 200, body: JSON.stringify(profile.toPrimitives()) };
   }
 
   if (resource === "/profile" && httpMethod === "PUT") {
@@ -131,15 +133,15 @@ export const handler = async (
         return { statusCode: 400, body: JSON.stringify({ error: "Invalid JSON body" }) };
       }
     }
-    const profile = {
+    const profile = UserProfile.fromPrimitives({
       email,
       firstName: payload.firstName,
       lastName: payload.lastName,
       displayName: payload.displayName,
       age: payload.age != null ? Number(payload.age) : undefined,
       unit: payload.unit,
-    };
-    await userStateRepository.putProfile(profile);
+    });
+    await updateUserProfile.execute(profile);
     return { statusCode: 200, body: JSON.stringify({ updated: true }) };
   }
 


### PR DESCRIPTION
## Summary
- add Email, Age and DistanceUnit value objects
- refactor UserProfile into an entity class
- create new GetUserProfile/UpdateUserProfile use cases
- adapt Dynamo repository and HTTP router to work with new entity
- add unit tests

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3c2cc5f4832f8c7b5ba6a213f92e