### PR TITLE
Fix PageRouter IAM policy

### DIFF
--- a/infrastructure/lib/stacks/compute-stack.test.ts
+++ b/infrastructure/lib/stacks/compute-stack.test.ts
@@ -73,4 +73,16 @@ describe("ComputeStack", () => {
       },
     });
   });
+
+  test("grants PageRouter permission to delete items in UserState", () => {
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith(["dynamodb:DeleteItem"]),
+          }),
+        ]),
+      },
+    });
+  });
 });

--- a/infrastructure/lib/stacks/compute-stack.ts
+++ b/infrastructure/lib/stacks/compute-stack.ts
@@ -154,7 +154,12 @@ export class ComputeStack extends cdk.Stack {
     );
     pageRouter.fn.addToRolePolicy(
       new iam.PolicyStatement({
-        actions: ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:Query"],
+        actions: [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query",
+        ],
         resources: [props.userStateTable.tableArn],
       })
     );


### PR DESCRIPTION
## Summary
- let PageRouter remove user state items
- ensure CloudFormation policy includes `dynamodb:DeleteItem`

## Testing
- `npm --prefix infrastructure run test:unit` *(fails: jest not found)*
- `npm --prefix src/backend run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7584b40c832faf008f4ab45d6820