### PR TITLE
Add Cognito auth support in Swagger

### DIFF
--- a/src/backend/src/docs/interfaces/http/swagger.ts
+++ b/src/backend/src/docs/interfaces/http/swagger.ts
@@ -17,7 +17,8 @@ const html = `<!DOCTYPE html>
         const specUrl = window.location.pathname + '.json';
         SwaggerUIBundle({
           url: specUrl,
-          dom_id: '#swagger-ui'
+          dom_id: '#swagger-ui',
+          persistAuthorization: true
         });
       };
     </script>

--- a/src/backend/src/docs/openapi.ts
+++ b/src/backend/src/docs/openapi.ts
@@ -4,6 +4,20 @@ export const openApiSpec = {
     title: "Sendeo API",
     version: "1.0.0",
   },
+  // API Gateway uses the default "prod" stage when no stage name is provided.
+  // Specify it here so Swagger UI generates the correct base URLs.
+  servers: [{ url: "/prod" }],
+  components: {
+    securitySchemes: {
+      cognitoAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+    },
+  },
+  // Require the Cognito bearer token for all operations except Swagger itself.
+  security: [{ cognitoAuth: [] }],
   paths: {
     "/routes": {
       get: {


### PR DESCRIPTION
## Summary
- define bearer auth security scheme in OpenAPI spec
- enable token persistence in Swagger UI

## Testing
- `npm run test:unit` in backend *(fails: jest not found)*
- `npm run test:unit` in infrastructure *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68790100efdc832fa0c4eae2c5d1fc51