### PR TITLE
Add confirm signup page and routing

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import HomePage from './pages/HomePage';
 import SignupPage from './pages/SignupPage';
 import LoginPage from './pages/LoginPage';
 import RoutesPage from './pages/RoutesPage';
+import ConfirmSignupPage from './pages/ConfirmSignupPage';
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/signup" element={<SignupPage />} />
+          <Route path="/confirm-signup" element={<ConfirmSignupPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/routes" element={<RoutesPage />} />
         </Routes>

--- a/src/frontend/src/pages/ConfirmSignupPage.tsx
+++ b/src/frontend/src/pages/ConfirmSignupPage.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Heading,
+  Input,
+  Stack,
+} from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import { confirmSignUp } from '../auth/cognito';
+
+const ConfirmSignupPage = () => {
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await confirmSignUp(email, code);
+      alert('Account confirmed. You can now log in.');
+      navigate('/login');
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        alert(err.message);
+      } else {
+        alert('Error confirming sign up');
+      }
+    }
+  };
+
+  return (
+    <Box maxW="md" mx="auto" mt={10} p={4} borderWidth="1px" borderRadius="lg">
+      <Heading mb={4}>Confirm Sign Up</Heading>
+      <form onSubmit={handleSubmit}>
+        <Stack spacing={3}>
+          <FormControl>
+            <FormLabel>Email</FormLabel>
+            <Input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Confirmation Code</FormLabel>
+            <Input
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              required
+            />
+          </FormControl>
+          <Button type="submit" colorScheme="blue">
+            Confirm
+          </Button>
+        </Stack>
+      </form>
+    </Box>
+  );
+};
+
+export default ConfirmSignupPage;

--- a/src/frontend/src/pages/SignupPage.tsx
+++ b/src/frontend/src/pages/SignupPage.tsx
@@ -13,7 +13,7 @@ const SignupPage = () => {
     try {
       await signUp(email, password);
       alert('Check your email for a confirmation code');
-      navigate('/login');
+      navigate('/confirm-signup');
     } catch (err: unknown) {
       if (err instanceof Error) {
         alert(err.message);


### PR DESCRIPTION
## Summary
- add ConfirmSignupPage
- add `/confirm-signup` route
- route signup completion to confirm page

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e2615b700832fb0b7f841861dedeb