### PR TITLE
Update Vite env typings

### DIFF
--- a/src/frontend/vite-env.d.ts
+++ b/src/frontend/vite-env.d.ts
@@ -2,6 +2,9 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string
+  readonly VITE_USER_POOL_ID: string
+  readonly VITE_CLIENT_ID: string
+  readonly VITE_REGION: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- extend `ImportMetaEnv` with Cognito and region variables for the frontend

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'babel__core', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687e26243434832f8422be452f84ed32