### PR TITLE
Add user profile and favorites pages with menu

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import SignupPage from './pages/SignupPage';
 import LoginPage from './pages/LoginPage';
 import RoutesPage from './pages/RoutesPage';
 import ConfirmSignupPage from './pages/ConfirmSignupPage';
+import UserProfilePage from './pages/UserProfilePage';
+import FavouritesPage from './pages/FavouritesPage';
 import ProtectedRoute from './components/ProtectedRoute';
 
 
@@ -25,6 +27,22 @@ function App() {
             element={
               <ProtectedRoute>
                 <RoutesPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/profile"
+            element={
+              <ProtectedRoute>
+                <UserProfilePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/favourites"
+            element={
+              <ProtectedRoute>
+                <FavouritesPage />
               </ProtectedRoute>
             }
           />

--- a/src/frontend/src/components/NavBar.tsx
+++ b/src/frontend/src/components/NavBar.tsx
@@ -8,7 +8,13 @@ import {
   Link,
   Image,
   useColorModeValue,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  IconButton,
 } from '@chakra-ui/react';
+import { FaUserCircle } from 'react-icons/fa';
 import { useContext } from 'react';
 import logoSrc from '../assets/logo.png';
 import { AuthContext } from '../contexts/AuthContext';
@@ -85,14 +91,20 @@ const NavBar = () => {
           )}
 
           {token && (
-            <Button
-              size="sm"
-              colorScheme="brand"
-              variant="outline"
-              onClick={() => setToken(null)}
-            >
-              Logout
-            </Button>
+            <Menu>
+              <MenuButton
+                as={IconButton}
+                aria-label="User menu"
+                icon={<FaUserCircle />}
+                variant="ghost"
+                size="lg"
+              />
+              <MenuList>
+                <MenuItem as={RouterLink} to="/profile">Profile Settings</MenuItem>
+                <MenuItem as={RouterLink} to="/favourites">Favourite Routes</MenuItem>
+                <MenuItem onClick={() => setToken(null)}>Logout</MenuItem>
+              </MenuList>
+            </Menu>
           )}
         </HStack>
       </Flex>

--- a/src/frontend/src/pages/FavouritesPage.tsx
+++ b/src/frontend/src/pages/FavouritesPage.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  List,
+  ListItem,
+  Spinner,
+} from '@chakra-ui/react';
+import { api } from '../services/api';
+
+const FavouritesPage = () => {
+  const [favourites, setFavourites] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchFavs = async () => {
+      try {
+        const { data } = await api.get('/favourites');
+        setFavourites(data.favourites || []);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchFavs();
+  }, []);
+
+  if (loading) {
+    return (
+      <Box textAlign="center" mt={10}>
+        <Spinner size="xl" />
+      </Box>
+    );
+  }
+
+  return (
+    <Box maxW="md" mx="auto" mt={10} p={4} borderWidth="1px" borderRadius="lg">
+      <Heading mb={4}>Favourite Routes</Heading>
+      <List spacing={2}>
+        {favourites.map((f) => (
+          <ListItem key={f}>{f}</ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default FavouritesPage;
+

--- a/src/frontend/src/pages/UserProfilePage.tsx
+++ b/src/frontend/src/pages/UserProfilePage.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  Text,
+  Spinner,
+  Stack,
+} from '@chakra-ui/react';
+import { api } from '../services/api';
+
+interface Profile {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  displayName?: string;
+  age?: number;
+  unit?: string;
+}
+
+const UserProfilePage = () => {
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const { data } = await api.get('/profile');
+        setProfile(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchProfile();
+  }, []);
+
+  if (loading) {
+    return (
+      <Box textAlign="center" mt={10}>
+        <Spinner size="xl" />
+      </Box>
+    );
+  }
+
+  if (!profile) return null;
+
+  return (
+    <Box maxW="md" mx="auto" mt={10} p={4} borderWidth="1px" borderRadius="lg">
+      <Heading mb={4}>Profile</Heading>
+      <Stack spacing={2}>
+        <Text>
+          <b>Email:</b> {profile.email}
+        </Text>
+        {profile.displayName && (
+          <Text>
+            <b>Display Name:</b> {profile.displayName}
+          </Text>
+        )}
+        {profile.firstName && (
+          <Text>
+            <b>First Name:</b> {profile.firstName}
+          </Text>
+        )}
+        {profile.lastName && (
+          <Text>
+            <b>Last Name:</b> {profile.lastName}
+          </Text>
+        )}
+        {profile.age != null && (
+          <Text>
+            <b>Age:</b> {profile.age}
+          </Text>
+        )}
+        {profile.unit && (
+          <Text>
+            <b>Unit:</b> {profile.unit}
+          </Text>
+        )}
+      </Stack>
+    </Box>
+  );
+};
+
+export default UserProfilePage;
+


### PR DESCRIPTION
## Summary
- introduce `UserProfilePage` to view user profile data
- add `FavouritesPage` to list favourite routes
- enhance `NavBar` with user menu (profile, favourites, logout)
- register new pages in router

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4b221538832fb6a10bfb52ee24b8