### PR TITLE
Update login flow to store profile

### DIFF
--- a/src/frontend/src/pages/LoginPage.tsx
+++ b/src/frontend/src/pages/LoginPage.tsx
@@ -13,6 +13,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { signIn } from '../auth/cognito';
 import axios from 'axios';
 import { AuthContext } from '../contexts/AuthContext';
+import { api } from '../services/api';
 
 const LoginPage = () => {
   const [email, setEmail] = useState('');
@@ -26,7 +27,7 @@ const LoginPage = () => {
       const token = await signIn(email, password);
       setToken(token);
       localStorage.setItem('token', token);
-      //await api.get('/profile');
+      await api.put('/profile', { email });
       navigate('/routes');
     } catch (err: unknown) {
       if (axios.isAxiosError(err)) {


### PR DESCRIPTION
## Summary
- update login flow to store the profile in the backend when signing in

## Testing
- `npm run test:unit` in `src/backend` *(fails: jest not found)*
- `npm run test:unit` in `infrastructure` *(fails: jest not found)*
- `npm test` in `src/frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e6f6c5e38832fae5cb9312a6aa68e