### PR TITLE
Add route polling in frontend

### DIFF
--- a/src/frontend/src/pages/RoutesPage.tsx
+++ b/src/frontend/src/pages/RoutesPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Box,
   Button,
@@ -11,7 +11,7 @@ import {
   useToast,
   Spinner,
 } from '@chakra-ui/react';
-import { GoogleMap, Marker, useLoadScript } from '@react-google-maps/api';
+import { GoogleMap, Marker, Polyline, useLoadScript } from '@react-google-maps/api';
 import { FaLocationArrow } from 'react-icons/fa';
 import { api } from '../services/api';
 
@@ -27,10 +27,14 @@ export default function RoutesPage() {
   const [maxDeltaKm, setMaxDeltaKm] = useState('');
   const [routesCount, setRoutesCount] = useState('');
   const [mode, setMode] = useState<'points' | 'distance'>('points');
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [routes, setRoutes] = useState<any[]>([]);
+  const [loadingRoutes, setLoadingRoutes] = useState(false);
   const toast = useToast();
 
   const { isLoaded, loadError } = useLoadScript({
-    googleMapsApiKey: GOOGLE_MAPS_API_KEY
+    googleMapsApiKey: GOOGLE_MAPS_API_KEY,
+    libraries: ['geometry'],
   });
 
   const handleMapClick = (e: google.maps.MapMouseEvent) => {
@@ -56,13 +60,35 @@ export default function RoutesPage() {
       routesCount: routesCount ? Number(routesCount) : undefined,
     };
     try {
-      await api.post('/routes', data);
+      const { data: resp } = await api.post('/routes', data);
       toast({ title: 'Route request submitted', status: 'success' });
+      setJobId(resp.jobId);
+      setRoutes([]);
+      setLoadingRoutes(true);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An unknown error occurred';
       toast({ title: 'Error requesting routes', status: 'error', description: message });
     }
   };
+
+  useEffect(() => {
+    if (!jobId) return;
+
+    const timer = setInterval(async () => {
+      try {
+        const { data } = await api.get(`/jobs/${jobId}/routes`);
+        if (Array.isArray(data) && data.length > 0) {
+          setRoutes(data);
+          setLoadingRoutes(false);
+          clearInterval(timer);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }, 2000);
+
+    return () => clearInterval(timer);
+  }, [jobId]);
 
   if (loadError) return <Box color="red.500">Map cannot be loaded right now.</Box>;
   if (!isLoaded) return <Flex justify="center" mt={12}><Spinner size="xl" /></Flex>;
@@ -181,11 +207,44 @@ export default function RoutesPage() {
           >
             {origin && <Marker position={origin} label="A" />}
             {mode === 'points' && destination && <Marker position={destination} label="B" />}
+            {routes.map((r, idx) => (
+              r.path ? (
+                <Polyline
+                  key={r.routeId}
+                  path={google.maps.geometry.encoding.decodePath(r.path)}
+                  options={{
+                    strokeColor: ['#ff6f00', '#388e3c', '#1976d2'][idx % 3],
+                    strokeOpacity: 0.8,
+                    strokeWeight: 4,
+                  }}
+                />
+              ) : null
+            ))}
           </GoogleMap>
         </Box>
         <Text fontSize="sm" color="gray.500" mt={-1}>
           Click on the map to set {origin ? (mode === 'points' && !destination ? 'destination' : 'origin') : 'origin'}.
         </Text>
+        {loadingRoutes && (
+          <Flex justify="center" my={4}>
+            <Spinner />
+          </Flex>
+        )}
+        {routes.length > 0 && (
+          <Stack spacing={3} mt={4}>
+            {routes.map((r) => (
+              <Box key={r.routeId} p={3} borderWidth="1px" borderRadius="md">
+                <Text fontWeight="bold">Route {r.routeId}</Text>
+                {r.distanceKm != null && (
+                  <Text>Distance: {r.distanceKm.toFixed(2)} km</Text>
+                )}
+                {r.duration != null && (
+                  <Text>Duration: {Math.round(r.duration / 60)} min</Text>
+                )}
+              </Box>
+            ))}
+          </Stack>
+        )}
       </Box>
     </Flex>
   );

--- a/src/frontend/vite-env.d.ts
+++ b/src/frontend/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_USER_POOL_ID: string
   readonly VITE_CLIENT_ID: string
   readonly VITE_REGION: string
+  readonly VITE_GOOGLE_MAPS_API_KEY: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- show Google API key in env typings
- poll job routes from the API in `RoutesPage`
- draw returned paths on the map and list route details

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5a382114832fb92780ac66aea398