### PR TITLE
Fix round-trip polyline joining

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -317,7 +317,7 @@ export const handler: SQSHandler = async (event) => {
         totalDuration += backLeg.durationSeconds;
         if (encoded && backLeg.encoded) {
           const c1 = new Path(encoded).Coordinates;
-          const c2 = new Path(backLeg.encoded).Coordinates.slice().reverse();
+          const c2 = new Path(backLeg.encoded).Coordinates.slice();
           encoded = Path.fromCoordinates([...c1, ...c2.slice(1)]).Encoded;
         } else {
           encoded = undefined;


### PR DESCRIPTION
## Summary
- keep return-leg order when combining round-trip segments
- mock return leg polyline and request behaviour in tests

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb934eb10832fb6b7fcc1e8be112c