### PR TITLE
Handle coordinate inputs in geocoder

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
@@ -60,6 +60,10 @@ describe("worker routes handler", () => {
     return require("./worker-routes").handler as any;
   }
 
+  function loadGeocode() {
+    return require("./worker-routes").geocode as any;
+  }
+
   it("saves decoded route when directions are returned", async () => {
     responseDataHolder.data = JSON.stringify({
       routes: [
@@ -477,5 +481,18 @@ describe("worker routes handler", () => {
     expect(mockPublish).toHaveBeenCalledTimes(1);
     const published = mockPublish.mock.calls[0][1];
     expect(published).toHaveLength(2);
+  });
+
+  it("parses coordinate strings without calling the API", async () => {
+    const geocode = loadGeocode();
+    const result = await geocode("41.38,2.17", "k");
+    expect(result).toEqual({ lat: 41.38, lng: 2.17 });
+    expect(httpsRequest).not.toHaveBeenCalled();
+  });
+
+  it("calls the API for address inputs", async () => {
+    const geocode = loadGeocode();
+    await geocode("Barcelona", "k");
+    expect(httpsRequest).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -37,10 +37,25 @@ function fetchJson<T = any>(url: string): Promise<T> {
   });
 }
 
-async function geocode(
+/**
+ * Geocode an address or parse provided coordinates.
+ *
+ * The function accepts plain address strings as well as "lat,lng" coordinate
+ * pairs. When the input matches a coordinate pattern it is returned directly
+ * without calling the Google Geocode API.
+ */
+export async function geocode(
   address: string,
   apiKey: string
 ): Promise<{ lat: number; lng: number }> {
+  const coordRegex = /^-?\d+(?:\.\d+)?,\s*-?\d+(?:\.\d+)?$/;
+  if (coordRegex.test(address)) {
+    const [latStr, lngStr] = address.split(/\s*,\s*/);
+    const lat = parseFloat(latStr);
+    const lng = parseFloat(lngStr);
+    return { lat, lng };
+  }
+
   const url =
     `https://maps.googleapis.com/maps/api/geocode/json` +
     `?address=${encodeURIComponent(address)}` +
@@ -50,7 +65,7 @@ async function geocode(
   const loc = res?.results?.[0]?.geometry?.location;
   if (!loc) {
     console.warn("⚠️ No geocoding result for", address, res);
-    throw new Error(`Geocoding failed for "${address}"`);
+    throw new Error(`Geocoding failed for \"${address}\"`);
   }
   return { lat: loc.lat, lng: loc.lng };
 }

--- a/src/frontend/src/pages/RoutesPage.tsx
+++ b/src/frontend/src/pages/RoutesPage.tsx
@@ -39,7 +39,7 @@ type Route = {
 };
 
 /**
- * Convert a lat/lng object to the "lat,lng" string that the backend API expects.
+ * Convert a lat/lng object to the "lat,lng" string accepted by the backend API.
  * We keep coordinates as objects for map interactions but serialize them when
  * sending requests.
  */
@@ -85,8 +85,8 @@ export default function RoutesPage() {
       toast({ title: 'Select an origin on the map.', status: 'warning' });
       return;
     }
-    // Serialize coordinates for the backend. The API expects "lat,lng" strings
-    // but we store them as objects while interacting with the map.
+    // Serialize coordinates for the backend. The API accepts "lat,lng" strings
+    // or addresses, but we store them as objects while interacting with the map.
     const data = {
       origin: toCoordinateString(origin),
       destination:


### PR DESCRIPTION
## Summary
- allow `geocode` to return coordinates directly when given `"lat,lng"` strings
- export `geocode` for testing and add tests for the new behaviour
- clarify in the frontend comments that coordinate strings are accepted

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880b3f31448832fb4521a26d5239110