### PR TITLE
Fix polyline merge for round trips

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -438,13 +438,21 @@ export const handler: SQSHandler = async (event) => {
           }
           totalDistance += backLeg.distanceMeters;
           totalDuration += backLeg.durationSeconds;
-          if (encoded && backLeg.encoded) {
-            const c1 = new Path(encoded).Coordinates;
-            const c2 = new Path(backLeg.encoded).Coordinates.slice();
-            encoded = Path.fromCoordinates([...c1, ...c2.slice(1)]).Encoded;
-          } else {
-            encoded = backLeg.encoded;
-          }
+            if (encoded && backLeg.encoded) {
+              const c1 = new Path(encoded).Coordinates;
+              const c2 = new Path(backLeg.encoded).Coordinates.slice();
+              if (
+                c1.length &&
+                c2.length &&
+                c1[c1.length - 1].Lat === c2[0].Lat &&
+                c1[c1.length - 1].Lng === c2[0].Lng
+              ) {
+                c2.shift();
+              }
+              encoded = Path.fromCoordinates([...c1, ...c2]).Encoded;
+            } else {
+              encoded = backLeg.encoded;
+            }
         }
       }
 


### PR DESCRIPTION
## Summary
- merge back leg polyline carefully when generating round trips

## Testing
- `npm test --silent` *(fails: ENOAUDIT)*

------
https://chatgpt.com/codex/tasks/task_e_68810b05a920832fb6458a525e7b3e51