### PR TITLE
Add Bedrock agent Lambda

### DIFF
--- a/docs/bedrock-agent-lambda.md
+++ b/docs/bedrock-agent-lambda.md
@@ -1,0 +1,8 @@
+# Bedrock Agent Lambda
+
+This Lambda invokes an Amazon Bedrock agent. The handler expects the following environment variables:
+
+- `AGENT_ID` – ID of the Bedrock agent
+- `AGENT_ALIAS_ID` – alias ID for the agent
+
+Deploy the compiled function using your preferred method (e.g. AWS CDK). When triggered through API Gateway, send a JSON payload with a `prompt` field.

--- a/infrastructure/lib/stacks/compute-stack.test.ts
+++ b/infrastructure/lib/stacks/compute-stack.test.ts
@@ -35,6 +35,8 @@ describe("ComputeStack", () => {
       metricsQueue,
       userPool,
       googleApiKeySecretName,
+      bedrockAgentId: "a",
+      bedrockAgentAliasId: "b",
     });
 
     template = Template.fromStack(stack);
@@ -50,8 +52,8 @@ describe("ComputeStack", () => {
     template.resourceCountIs("AWS::ApiGateway::Authorizer", 1);
   });
 
-  test("defines six Lambda functions", () => {
-    template.resourceCountIs("AWS::Lambda::Function", 7);
+  test("defines Lambda functions", () => {
+    template.resourceCountIs("AWS::Lambda::Function", 8);
   });
 
   test("creates two SQS event source mappings", () => {

--- a/infrastructure/lib/stacks/compute-stack.ts
+++ b/infrastructure/lib/stacks/compute-stack.ts
@@ -20,6 +20,8 @@ export interface ComputeStackProps extends cdk.StackProps {
   readonly appSyncUrl?: string;
   readonly appSyncApiKey?: string;
   readonly appSyncRegion?: string;
+  readonly bedrockAgentId?: string;
+  readonly bedrockAgentAliasId?: string;
 }
 
 export class ComputeStack extends cdk.Stack {
@@ -224,6 +226,21 @@ export class ComputeStack extends cdk.Stack {
         { path: "swagger", methods: ["GET"] },
         { path: "swagger.json", methods: ["GET"] },
       ],
+    });
+
+    // 8) InvokeAgent → POST /agent
+    new HttpLambda(this, "InvokeAgent", {
+      entry: path.join(
+        __dirname,
+        "../../../src/backend/src/bedrock"
+      ),
+      handler: "invoke-agent.handler",
+      api,
+      environment: {
+        AGENT_ID: props.bedrockAgentId ?? "",
+        AGENT_ALIAS_ID: props.bedrockAgentAliasId ?? "",
+      },
+      routes: [{ path: "agent", methods: ["POST"], authorizer }],
     });
   }
 }

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -28,6 +28,7 @@
     "@aws-sdk/protocol-http": "^3.370.0",
     "@aws-sdk/signature-v4": "^3.370.0",
     "@mapbox/polyline": "^1.2.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "@aws-sdk/client-bedrock-agent-runtime": "^3.835.0"
   }
 }

--- a/src/backend/src/bedrock/invoke-agent.ts
+++ b/src/backend/src/bedrock/invoke-agent.ts
@@ -1,0 +1,19 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { BedrockAgentRuntimeClient, InvokeAgentCommand } from '@aws-sdk/client-bedrock-agent-runtime';
+
+const agent = new BedrockAgentRuntimeClient({});
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const body = event.body ? JSON.parse(event.body) : {};
+  const resp = await agent.send(
+    new InvokeAgentCommand({
+      agentId: process.env.AGENT_ID!,
+      agentAliasId: process.env.AGENT_ALIAS_ID!,
+      inputText: body.prompt,
+    })
+  );
+  return {
+    statusCode: 200,
+    body: resp.completion ?? '',
+  };
+};


### PR DESCRIPTION
## Summary
- add new Lambda to call the Bedrock Agent runtime
- expose environment variables for Bedrock in CDK stack
- document how to deploy the agent Lambda

## Testing
- `npm run test:unit` *(fails: jest not found)*
- `npm run test:unit` in `infrastructure` *(fails: jest not found)*
- `npx tsc -p src/backend/tsconfig.json` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6887ca6732a8832fa683b28e567d7e23