### PR TITLE
Update Dynamo favourite query

### DIFF
--- a/src/backend/src/users/infrastructure/dynamodb/dynamo-user-state-repository.test.ts
+++ b/src/backend/src/users/infrastructure/dynamodb/dynamo-user-state-repository.test.ts
@@ -60,11 +60,11 @@ describe('DynamoUserStateRepository', () => {
     expect(cmd).toBeInstanceOf(QueryCommand);
     expect((cmd as any).input).toEqual({
       TableName: tableName,
-      KeyConditionExpression: 'PK = :pk',
-      ExpressionAttributeValues: { ':pk': { S: `USER#${email.Value}` } },
+      KeyConditionExpression: 'PK = :pk AND begins_with(SK, :fav)',
+      ExpressionAttributeValues: { ':pk': { S: `USER#${email.Value}` }, ':fav': { S: 'FAV#' } },
     });
 
-    expect(result).toEqual(['FAV#1', 'FAV#2']);
+    expect(result).toEqual(['1', '2']);
   });
 
   it('getFavourites returns empty array if no items', async () => {

--- a/src/backend/src/users/infrastructure/dynamodb/dynamo-user-state-repository.ts
+++ b/src/backend/src/users/infrastructure/dynamodb/dynamo-user-state-repository.ts
@@ -40,13 +40,14 @@ export class DynamoUserStateRepository implements UserStateRepository {
     const res = await this.client.send(
       new QueryCommand({
         TableName: this.tableName,
-        KeyConditionExpression: "PK = :pk",
+        KeyConditionExpression: "PK = :pk AND begins_with(SK, :fav)",
         ExpressionAttributeValues: {
           ":pk": { S: `USER#${email}` },
+          ":fav": { S: "FAV#" },
         },
       })
     );
-    return (res.Items || []).map((i) => i.SK.S!);
+    return (res.Items || []).map((i) => i.SK.S!.slice(4));
   }
 
   async getProfile(email: Email): Promise<UserProfile | null> {


### PR DESCRIPTION
## Summary
- filter favourites by prefix in DynamoUserStateRepository
- strip the route prefix when returning favourite IDs
- update Dynamo tests for new query

## Testing
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888755f81f8832f8cdea77cebd68b59