### PR TITLE
feat: describe routes

### DIFF
--- a/infrastructure/graphql/schema.graphql
+++ b/infrastructure/graphql/schema.graphql
@@ -3,6 +3,7 @@ type Route {
   distanceKm: Float
   duration: Int
   path: String
+  description: String
 }
 
 input RouteInput {
@@ -10,6 +11,7 @@ input RouteInput {
   distanceKm: Float
   duration: Int
   path: String
+  description: String
 }
 
 type Mutation {

--- a/src/backend/src/routes/domain/entities/route-entity.ts
+++ b/src/backend/src/routes/domain/entities/route-entity.ts
@@ -9,6 +9,7 @@ export interface RouteProps {
   readonly distanceKm?: DistanceKm;
   readonly duration?: Duration;
   readonly path?: Path;
+  readonly description?: string;
 }
 
 export class Route {
@@ -39,5 +40,13 @@ export class Route {
 
   get path(): Path | undefined {
     return this.props.path;
+  }
+
+  get description(): string | undefined {
+    return this.props.description;
+  }
+
+  set description(desc: string | undefined) {
+    this.props.description = desc;
   }
 }

--- a/src/backend/src/routes/interfaces/appsync-client.ts
+++ b/src/backend/src/routes/interfaces/appsync-client.ts
@@ -68,6 +68,7 @@ export async function publishRoutesGenerated(jobId: string, routes: Route[]) {
     distanceKm: r.distanceKm?.Value,
     duration: r.duration?.Value,
     path: r.path?.Encoded,
+    description: r.description,
   }));
   await send(
     `mutation PublishRoutesGenerated($jobId: ID!, $routes: [RouteInput]!) {\n  publishRoutesGenerated(jobId: $jobId, routes: $routes)\n}`,

--- a/src/handlers/describe-route.ts
+++ b/src/handlers/describe-route.ts
@@ -1,0 +1,43 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import polyline from "@mapbox/polyline";
+
+const bedrock = new BedrockRuntimeClient({});
+
+async function fetchWeather(lat: number, lng: number): Promise<string> {
+  try {
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}&current=temperature_2m`;
+    const res = await fetch(url);
+    const data: any = await res.json();
+    const t = data?.current?.temperature_2m;
+    return typeof t === "number" ? `Current temperature ${t}\u00B0C.` : "";
+  } catch {
+    return "";
+  }
+}
+
+export async function describeRoute(
+  encodedPath: string,
+  modelId = "anthropic.claude-instant-v1"
+): Promise<string> {
+  if (!encodedPath) return "";
+  const coords = polyline.decode(encodedPath);
+  const [lat, lng] = coords[0] || [];
+  const weather = lat !== undefined ? await fetchWeather(lat, lng) : "";
+  const prompt = `You are a helpful assistant. ${weather} Describe the walking route for these coordinates: ${JSON.stringify(coords)}`;
+  try {
+    const resp = await bedrock.send(
+      new InvokeModelCommand({
+        modelId,
+        contentType: "application/json",
+        accept: "application/json",
+        body: Buffer.from(JSON.stringify({ prompt, maxTokensToSample: 256 })),
+      })
+    );
+    const text = await new Response(resp.body as any).text();
+    const data = JSON.parse(text);
+    return data.completion ?? data.output ?? text;
+  } catch (err) {
+    console.warn("[describeRoute] failed", err);
+    return "";
+  }
+}


### PR DESCRIPTION
## Summary
- describe routes with Bedrock and optional weather context
- publish descriptions with generated routes
- expose descriptions in GraphQL schema

## Testing
- `npm --prefix src/backend run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_688f3d3f53a8832f871dd31311d0a204