### PR TITLE
Add route descriptions across UI and API

### DIFF
--- a/src/backend/src/routes/infrastructure/dynamodb/dynamo-route-repository.test.ts
+++ b/src/backend/src/routes/infrastructure/dynamodb/dynamo-route-repository.test.ts
@@ -53,6 +53,7 @@ describe("DynamoRouteRepository", () => {
       distanceKm: new DistanceKm(5),
       duration: new Duration(10),
       path,
+      description: "desc",
     });
 
     const now = 1_600_000_000;
@@ -69,6 +70,7 @@ describe("DynamoRouteRepository", () => {
       path: { S: path.Encoded },
       createdAt: { N: now.toString() },
       ttl: { N: (now + 60).toString() },
+      description: { S: "desc" },
     };
 
     expect(mockPut).toHaveBeenCalledWith({
@@ -95,6 +97,7 @@ describe("DynamoRouteRepository", () => {
       distanceKm: { N: "5" },
       duration: { N: "10" },
       path: { S: encoded },
+      description: { S: "desc" },
     };
     mockSend.mockResolvedValueOnce({ Item: returned });
 
@@ -108,6 +111,7 @@ describe("DynamoRouteRepository", () => {
     expect(route?.jobId?.Value).toBe(jobId);
     expect(route?.distanceKm?.Value).toBe(5);
     expect(route?.duration?.Value).toBe(10);
+    expect(route?.description).toBe("desc");
     expect(
       route?.path?.Coordinates.map((c) => ({ lat: c.Lat, lng: c.Lng }))
     ).toEqual([
@@ -124,6 +128,7 @@ describe("DynamoRouteRepository", () => {
         {
           routeId: { S: routeId },
           jobId: { S: jobId },
+          description: { S: "d" },
         },
       ],
     };
@@ -139,5 +144,6 @@ describe("DynamoRouteRepository", () => {
     });
     expect(res).toHaveLength(1);
     expect(res[0].jobId?.Value).toBe(jobId);
+    expect(res[0].description).toBe("d");
   });
 });

--- a/src/backend/src/routes/infrastructure/dynamodb/dynamo-route-repository.ts
+++ b/src/backend/src/routes/infrastructure/dynamodb/dynamo-route-repository.ts
@@ -27,6 +27,7 @@ export class DynamoRouteRepository implements RouteRepository {
       item.distanceKm = { N: route.distanceKm.Value.toString() };
     if (route.duration) item.duration = { N: route.duration.Value.toString() };
     if (route.path) item.path = { S: route.path.Encoded };
+    if (route.description) item.description = { S: route.description };
 
     const ttlEnv = process.env.ROUTES_TTL;
     if (ttlEnv) {
@@ -60,6 +61,7 @@ export class DynamoRouteRepository implements RouteRepository {
         ? new Duration(parseFloat(res.Item.duration.N!))
         : undefined,
       path: res.Item.path ? new Path(res.Item.path.S!) : undefined,
+      description: res.Item.description?.S,
     });
   }
 
@@ -77,6 +79,7 @@ export class DynamoRouteRepository implements RouteRepository {
             : undefined,
           duration: item.duration ? new Duration(+item.duration.N!) : undefined,
           path: item.path ? new Path(item.path.S!) : undefined,
+          description: item.description?.S,
         })
     );
   }
@@ -102,6 +105,7 @@ export class DynamoRouteRepository implements RouteRepository {
             : undefined,
           duration: item.duration ? new Duration(+item.duration.N!) : undefined,
           path: item.path ? new Path(item.path.S!) : undefined,
+          description: item.description?.S,
         })
     );
   }

--- a/src/backend/src/routes/interfaces/http/page-router.test.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.test.ts
@@ -103,6 +103,7 @@ describe("page router get route", () => {
         LatLng.fromNumbers(0, 0),
         LatLng.fromNumbers(1, 1),
       ]),
+      description: "desc",
     });
     mockFindById.mockResolvedValueOnce(route);
 
@@ -119,6 +120,7 @@ describe("page router get route", () => {
       distanceKm: 2,
       duration: 100,
       path: route.path!.Encoded,
+      description: "desc",
     });
   });
 });
@@ -149,6 +151,7 @@ describe("page router list routes", () => {
         LatLng.fromNumbers(10, 10),
         LatLng.fromNumbers(20, 20),
       ]),
+      description: "a",
     });
     const route2 = new Route({
       routeId: UUID.generate(),
@@ -158,6 +161,7 @@ describe("page router list routes", () => {
         LatLng.fromNumbers(30, 30),
         LatLng.fromNumbers(40, 40),
       ]),
+      description: "b",
     });
     mockFindAll.mockResolvedValueOnce([route1, route2]);
 
@@ -173,12 +177,14 @@ describe("page router list routes", () => {
         distanceKm: 1,
         duration: 10,
         path: route1.path!.Encoded,
+        description: "a",
       },
       {
         routeId: route2.routeId.Value,
         distanceKm: 2,
         duration: 20,
         path: route2.path!.Encoded,
+        description: "b",
       },
     ]);
   });
@@ -208,7 +214,13 @@ describe("page router list routes by jobId", () => {
     expect(mockFindByJobId).toHaveBeenCalledWith(jobId.Value);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual([
-      { routeId: r.routeId.Value, distanceKm: undefined, duration: undefined, path: undefined },
+      {
+        routeId: r.routeId.Value,
+        distanceKm: undefined,
+        duration: undefined,
+        path: undefined,
+        description: undefined,
+      },
     ]);
   });
 });
@@ -286,6 +298,7 @@ describe("finish route", () => {
         LatLng.fromNumbers(0, 0),
         LatLng.fromNumbers(1, 1),
       ]),
+      description: "desc",
     });
     mockFindById.mockResolvedValueOnce(route);
     mockGetRouteStart.mockResolvedValueOnce(1000);
@@ -314,6 +327,8 @@ describe("finish route", () => {
       route.routeId.Value,
       expect.any(String)
     );
+    const summary = JSON.parse(mockPublishFinished.mock.calls[0][2]);
+    expect(summary.description).toBe("desc");
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
     expect(body).toEqual({
@@ -321,6 +336,7 @@ describe("finish route", () => {
       distanceKm: 2,
       duration: 100,
       path: route.path!.Encoded,
+      description: "desc",
       actualDuration: expect.any(Number),
     });
   });

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -43,6 +43,7 @@ export const handler = async (
             distanceKm: r.distanceKm?.Value,
             duration: r.duration?.Value,
             path: r.path?.Encoded,
+            description: r.description,
           }))
         ),
       };
@@ -80,6 +81,7 @@ export const handler = async (
         distanceKm: route.distanceKm?.Value,
         duration: route.duration?.Value,
         path: route.path?.Encoded,
+        description: route.description,
       }),
     };
   }
@@ -105,6 +107,7 @@ export const handler = async (
             distanceKm: r.distanceKm?.Value,
             duration: r.duration?.Value,
             path: r.path?.Encoded,
+            description: r.description,
           }))
         ),
       };
@@ -212,6 +215,7 @@ export const handler = async (
           distanceKm: route.distanceKm?.Value,
           duration: route.duration?.Value,
           path: route.path?.Encoded,
+          description: route.description,
           ...(actualDuration != null ? { actualDuration } : {}),
         })
       );
@@ -227,6 +231,7 @@ export const handler = async (
         distanceKm: route.distanceKm?.Value,
         duration: route.duration?.Value,
         path: route.path?.Encoded,
+        description: route.description,
         ...(actualDuration != null ? { actualDuration } : {}),
       }),
     };

--- a/src/frontend/src/pages/FavouritesPage.tsx
+++ b/src/frontend/src/pages/FavouritesPage.tsx
@@ -20,6 +20,7 @@ interface RouteDetails {
   routeId: string;
   distanceKm?: number;
   duration?: number;
+  description?: string;
 }
 
 const FavouritesPage = () => {
@@ -118,6 +119,11 @@ const FavouritesPage = () => {
                   {f.distanceKm !== undefined && (
                     <Text fontSize="sm" color="gray.600">
                       Distance: {f.distanceKm.toFixed(2)} km
+                    </Text>
+                  )}
+                  {f.description && (
+                    <Text fontSize="sm" color="gray.500" noOfLines={1}>
+                      {f.description}
                     </Text>
                   )}
                 </Box>

--- a/src/frontend/src/pages/RouteDetailPage.tsx
+++ b/src/frontend/src/pages/RouteDetailPage.tsx
@@ -36,8 +36,9 @@ export default function RouteDetailPage() {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   type Route = {
-    id: string;
+    routeId: string;
     path: string;
+    description?: string;
     // Add other route properties as needed
   };
 
@@ -155,6 +156,12 @@ export default function RouteDetailPage() {
     <Box py={8} minH="100vh" bg="gray.50">
       <Stack spacing={6} align="center">
         <Heading>Route {routeId}</Heading>
+
+        {route?.description && (
+          <Text color="gray.600" textAlign="center">
+            {route.description}
+          </Text>
+        )}
 
         <Box w={['90%', '800px']} h="500px" borderRadius="md" overflow="hidden">
           <GoogleMap

--- a/src/frontend/src/pages/RoutesPage.tsx
+++ b/src/frontend/src/pages/RoutesPage.tsx
@@ -64,6 +64,7 @@ export default function RoutesPage() {
     routeId: string;
     path?: string;
     distanceKm?: number;
+    description?: string;
     [key: string]: unknown;
   }
   const [routes, setRoutes] = useState<Route[]>([]);
@@ -501,6 +502,11 @@ export default function RoutesPage() {
                     <Text fontSize="lg" color="gray.600">
                       Distance: {r.distanceKm?.toFixed(2)} km
                     </Text>
+                    {r.description && (
+                      <Text fontSize="sm" color="gray.500" noOfLines={1}>
+                        {r.description}
+                      </Text>
+                    )}
                   </Box>
 
                   <HStack spacing={2}>


### PR DESCRIPTION
## Summary
- support optional route descriptions across Routes, Route Detail, and Favourites pages
- persist and expose route descriptions via DynamoDB repository and HTTP endpoints

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm run test:unit` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` (frontend) *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d91ae24832f96223201070da84a