### PR TITLE
(TESTS) Fix stage-dependent stack tests and include route descriptions

### DIFF
--- a/infrastructure/lib/stacks/appsync-stack.test.ts
+++ b/infrastructure/lib/stacks/appsync-stack.test.ts
@@ -30,6 +30,7 @@ describe("AppSyncStack", () => {
     const stack = new AppSyncStack(app, "TestAppSyncStack", {
       env: TEST_ENV,
       userPool,
+      stage: 'test',
     });
 
     template = Template.fromStack(stack);
@@ -37,7 +38,7 @@ describe("AppSyncStack", () => {
 
   test("creates a GraphQL API with Cognito auth", () => {
     template.hasResourceProperties("AWS::AppSync::GraphQLApi", {
-      Name: "SendeoGraphQL",
+      Name: "SendeoGraphQL-test",
       AuthenticationType: "AMAZON_COGNITO_USER_POOLS",
       LogConfig: {
         FieldLogLevel: "ALL",
@@ -47,14 +48,14 @@ describe("AppSyncStack", () => {
 
   test("outputs the API url", () => {
     template.hasOutput("AppSyncUrl", {
-      Export: { Name: "SendeoAppSyncUrl" },
+      Export: { Name: "SendeoAppSyncUrl-test" },
     });
   });
 
   test("conditionally outputs the API key", () => {
     if (Object.keys(template.findOutputs("AppSyncApiKey", true)).length > 0) {
       template.hasOutput("AppSyncApiKey", {
-        Export: { Name: "SendeoAppSyncApiKey" },
+        Export: { Name: "SendeoAppSyncApiKey-test" },
       });
     }
   });

--- a/infrastructure/lib/stacks/auth-stack.test.ts
+++ b/infrastructure/lib/stacks/auth-stack.test.ts
@@ -9,6 +9,7 @@ describe('AuthStack', () => {
     const app = new cdk.App();
     const stack = new AuthStack(app, 'TestAuthStack', {
       env: { account: '123456789012', region: 'us-east-1' },
+      stage: 'test',
     });
     template = Template.fromStack(stack);
   });
@@ -40,7 +41,7 @@ describe('AuthStack', () => {
   test('exports the UserPoolClientId output for cross-stack reference', () => {
     template.hasOutput('UserPoolClientId', {
       Export: {
-        Name: 'SendeoUserPoolClientId',
+        Name: 'SendeoUserPoolClientId-test',
       },
       Value: {
         'Ref': Match.stringLikeRegexp('UserPoolClient'),

--- a/infrastructure/lib/stacks/compute-stack.test.ts
+++ b/infrastructure/lib/stacks/compute-stack.test.ts
@@ -37,6 +37,7 @@ describe("ComputeStack", () => {
       googleApiKeySecretName,
       bedrockAgentId: "a",
       bedrockAgentAliasId: "b",
+      stage: 'test',
     });
 
     template = Template.fromStack(stack);
@@ -44,7 +45,7 @@ describe("ComputeStack", () => {
 
   test("creates an API Gateway named SendeoApi", () => {
     template.hasResourceProperties("AWS::ApiGateway::RestApi", {
-      Name: "SendeoApi",
+      Name: "SendeoApi-test",
     });
   });
 

--- a/infrastructure/lib/stacks/frontend-stack.test.ts
+++ b/infrastructure/lib/stacks/frontend-stack.test.ts
@@ -12,6 +12,7 @@ describe('FrontendStack', () => {
       repoOwner: 'owner',
       repoName: 'repo',
       oauthTokenSecretName: 'tokenSecret',
+      stage: 'test',
     });
     template = Template.fromStack(stack);
   });
@@ -28,7 +29,7 @@ describe('FrontendStack', () => {
 
   test('outputs the Amplify URL', () => {
     template.hasOutput('AmplifyURL', {
-      Description: 'URL pública de la rama main en Amplify',
+      Description: 'URL pública de la rama main (test)',
     });
   });
 });

--- a/infrastructure/lib/stacks/queue-stack.test.ts
+++ b/infrastructure/lib/stacks/queue-stack.test.ts
@@ -9,6 +9,7 @@ describe('QueueStack', () => {
     const app = new cdk.App();
     const stack = new QueueStack(app, 'TestQueueStack', {
       env: { account: '123456789012', region: 'us-east-1' },
+      stage: 'test',
     });
     template = Template.fromStack(stack);
   });
@@ -19,7 +20,7 @@ describe('QueueStack', () => {
 
   test('RouteJobsQueue configured with DLQ and visibility timeout', () => {
     template.hasResourceProperties('AWS::SQS::Queue', {
-      QueueName: 'RouteJobsQueue',
+      QueueName: 'RouteJobsQueue-test',
       VisibilityTimeout: 60,
       RedrivePolicy: {
         maxReceiveCount: 5,
@@ -32,7 +33,7 @@ describe('QueueStack', () => {
 
   test('MetricsQueue has visibility timeout of 30 seconds', () => {
     template.hasResourceProperties('AWS::SQS::Queue', {
-      QueueName: 'MetricsQueue',
+      QueueName: 'MetricsQueue-test',
       VisibilityTimeout: 30,
     });
   });

--- a/infrastructure/lib/stacks/storage-stack.test.ts
+++ b/infrastructure/lib/stacks/storage-stack.test.ts
@@ -9,6 +9,7 @@ describe('StorageStack', () => {
     const app = new cdk.App();
     const stack = new StorageStack(app, 'TestStorageStack', {
       env: { account: '123456789012', region: 'us-east-1' },
+      stage: 'test',
     });
     template = Template.fromStack(stack);
   });
@@ -19,7 +20,7 @@ describe('StorageStack', () => {
 
   test('Routes table has the correct properties', () => {
     template.hasResourceProperties('AWS::DynamoDB::Table', {
-      TableName: 'Routes',
+      TableName: 'Routes-test',
       BillingMode: 'PAY_PER_REQUEST',
       TimeToLiveSpecification: {
         AttributeName: 'ttl',
@@ -68,7 +69,7 @@ describe('StorageStack', () => {
 
   test('UserState table has the correct properties', () => {
     template.hasResourceProperties('AWS::DynamoDB::Table', {
-      TableName: 'UserState',
+      TableName: 'UserState-test',
       BillingMode: 'PAY_PER_REQUEST',
       KeySchema: [
         { AttributeName: 'PK', KeyType: 'HASH' },

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -44,6 +44,7 @@ export const handler = async (
             distanceKm: r.distanceKm?.Value,
             duration: r.duration?.Value,
             path: r.path?.Encoded,
+            description: r.description,
           }))
         ),
       };
@@ -117,6 +118,7 @@ export const handler = async (
             distanceKm: r.distanceKm?.Value,
             duration: r.duration?.Value,
             path: r.path?.Encoded,
+            description: r.description,
           }))
         ),
       };


### PR DESCRIPTION
## Summary
- ensure infrastructure stack tests provide a stage and expect suffixed resource names
- return route descriptions when listing routes

## Testing
- `npm run test:unit` (infrastructure)
- `npx jest` (backend)


------
https://chatgpt.com/codex/tasks/task_e_689ef7114a10832f8272fde84ed8d415