### PR TITLE
feat: centralize env var configuration

### DIFF
--- a/src/backend/src/config.ts
+++ b/src/backend/src/config.ts
@@ -1,0 +1,19 @@
+const getEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    if (process.env.NODE_ENV === "test") {
+      return name;
+    }
+    throw new Error(`Environment variable ${name} is required`);
+  }
+  return value;
+};
+
+const config = {
+  ROUTES_TABLE: getEnv("ROUTES_TABLE"),
+  USER_STATE_TABLE: getEnv("USER_STATE_TABLE"),
+  METRICS_QUEUE: getEnv("METRICS_QUEUE"),
+};
+
+export default config;
+export { config };

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -9,16 +9,17 @@ import { ListRoutesUseCase } from "../../application/use-cases/list-routes";
 import { GetRouteDetailsUseCase } from "../../application/use-cases/get-route-details";
 import { corsHeaders } from "../../../http/cors";
 import { describeRoute } from "../../handlers/describe-route";
+import config from "../../../config";
 
 const dynamo = new DynamoDBClient({});
 const sqs = new SQSClient({});
 const routeRepository = new DynamoRouteRepository(
   dynamo,
-  process.env.ROUTES_TABLE!
+  config.ROUTES_TABLE,
 );
 const userStateRepository = new DynamoUserStateRepository(
   dynamo,
-  process.env.USER_STATE_TABLE!
+  config.USER_STATE_TABLE,
 );
 const listRoutes = new ListRoutesUseCase(routeRepository);
 const getRouteDetails = new GetRouteDetailsUseCase(routeRepository);
@@ -159,7 +160,7 @@ export const handler = async (
     await userStateRepository.putRouteStart(email, routeId, ts);
     await sqs.send(
       new SendMessageCommand({
-        QueueUrl: process.env.METRICS_QUEUE!,
+        QueueUrl: config.METRICS_QUEUE,
         MessageBody: JSON.stringify({
           event: "started",
           routeId,
@@ -206,7 +207,7 @@ export const handler = async (
 
     await sqs.send(
       new SendMessageCommand({
-        QueueUrl: process.env.METRICS_QUEUE!,
+        QueueUrl: config.METRICS_QUEUE,
         MessageBody: JSON.stringify({
           event: "finished",
           routeId,

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -9,9 +9,10 @@ import { UUID } from "../../domain/value-objects/uuid-value-object";
 import { DynamoRouteRepository } from "../../infrastructure/dynamodb/dynamo-route-repository";
 import { publishRoutesGenerated } from "../appsync-client";
 import { fetchJson, getGoogleKey } from "../shared/utils";
+import config from "../../../config";
 
 const dynamo = new DynamoDBClient({});
-const repository = new DynamoRouteRepository(dynamo, process.env.ROUTES_TABLE!);
+const repository = new DynamoRouteRepository(dynamo, config.ROUTES_TABLE);
 
 /** Geocode or parse “lat,lng” */
 async function geocode(address: string, apiKey: string) {

--- a/src/backend/src/users/interfaces/http/favourite-routes.ts
+++ b/src/backend/src/users/interfaces/http/favourite-routes.ts
@@ -8,11 +8,12 @@ import {
 import { AddFavouriteUseCase, FavouriteAlreadyExistsError } from "../../application/use-cases/add-favourite";
 import { RemoveFavouriteUseCase } from "../../application/use-cases/remove-favourite";
 import { corsHeaders } from "../../../http/cors";
+import config from "../../../config";
 
 const dynamo = new DynamoDBClient({});
 const repository = new DynamoUserStateRepository(
   dynamo,
-  process.env.USER_STATE_TABLE!
+  config.USER_STATE_TABLE,
 );
 const addFavourite = new AddFavouriteUseCase(repository);
 const removeFavourite = new RemoveFavouriteUseCase(repository);

--- a/src/backend/src/users/interfaces/http/profile-routes.ts
+++ b/src/backend/src/users/interfaces/http/profile-routes.ts
@@ -6,11 +6,12 @@ import { UpdateUserProfileUseCase } from "../../application/use-cases/update-use
 import { Email } from "../../../routes/domain/value-objects/email-value-object";
 import { UserProfile } from "../../domain/entities/user-profile";
 import { corsHeaders } from "../../../http/cors";
+import config from "../../../config";
 
 const dynamo = new DynamoDBClient({});
 const repository = new DynamoUserStateRepository(
   dynamo,
-  process.env.USER_STATE_TABLE!
+  config.USER_STATE_TABLE,
 );
 const getUserProfile = new GetUserProfileUseCase(repository);
 const updateUserProfile = new UpdateUserProfileUseCase(repository);


### PR DESCRIPTION
## Summary
- validate required environment variables at startup
- consume config module instead of `process.env.*!` in http and worker routes

## Testing
- `npx jest --silent`

------
https://chatgpt.com/codex/tasks/task_e_68a337b6d3b0832fb7e2fefce05ccd17