### PR TITLE
feat: push metrics to CloudWatch

### DIFF
--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -27,6 +27,7 @@
     "@aws-sdk/client-dynamodb": "^3.540.0",
     "@aws-sdk/client-secrets-manager": "^3.835.0",
     "@aws-sdk/client-sqs": "^3.540.0",
+    "@aws-sdk/client-cloudwatch": "^3.540.0",
     "@aws-sdk/protocol-http": "^3.370.0",
     "@aws-sdk/signature-v4": "^3.370.0",
     "@mapbox/polyline": "^1.2.1",

--- a/src/backend/src/routes/interfaces/sqs/metrics-processor.test.ts
+++ b/src/backend/src/routes/interfaces/sqs/metrics-processor.test.ts
@@ -1,0 +1,72 @@
+const sendMock = jest.fn();
+
+jest.mock(
+  "@aws-sdk/client-cloudwatch",
+  () => ({
+    CloudWatchClient: jest.fn().mockImplementation(() => ({ send: sendMock })),
+    PutMetricDataCommand: jest.fn().mockImplementation((input) => ({ input })),
+  }),
+  { virtual: true }
+);
+
+describe("metrics processor", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    process.env.METRICS_NAMESPACE = "TestNS";
+  });
+
+  it("publishes generated routes count", async () => {
+    const { handler } = require("./metrics-processor");
+    await handler({
+      Records: [
+        {
+          body: JSON.stringify({
+            event: "routes_generated",
+            count: 3,
+            timestamp: 1000,
+          }),
+        },
+      ],
+    });
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const call = sendMock.mock.calls[0][0];
+    expect(call.input.Namespace).toBe("TestNS");
+    expect(call.input.MetricData).toEqual([
+      expect.objectContaining({
+        MetricName: "RoutesGenerated",
+        Value: 3,
+        Unit: "Count",
+      }),
+    ]);
+  });
+
+  it("publishes metrics for finished routes", async () => {
+    const { handler } = require("./metrics-processor");
+    await handler({
+      Records: [
+        {
+          body: JSON.stringify({
+            event: "finished",
+            actualDuration: 120,
+            timestamp: 2000,
+          }),
+        },
+      ],
+    });
+    const data = sendMock.mock.calls[0][0].input.MetricData;
+    expect(data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          MetricName: "RouteFinished",
+          Value: 1,
+          Unit: "Count",
+        }),
+        expect.objectContaining({
+          MetricName: "ActualDuration",
+          Value: 120,
+          Unit: "Seconds",
+        }),
+      ])
+    );
+  });
+});

--- a/src/backend/src/routes/interfaces/sqs/metrics-processor.ts
+++ b/src/backend/src/routes/interfaces/sqs/metrics-processor.ts
@@ -1,6 +1,60 @@
-export const handler = async (event: any) => {
-  return {
-    statusCode: 200,
-    body: JSON.stringify({ ok: true }),
-  };
+import { SQSHandler } from "aws-lambda";
+import { CloudWatchClient, PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+
+const cw = new CloudWatchClient({});
+
+export const handler: SQSHandler = async (event) => {
+  const namespace = process.env.METRICS_NAMESPACE!;
+  const metricData: any[] = [];
+
+  for (const record of event.Records || []) {
+    try {
+      const msg = JSON.parse(record.body);
+      const ts = msg.timestamp ? new Date(msg.timestamp) : new Date();
+      switch (msg.event) {
+        case "routes_generated":
+          metricData.push({
+            MetricName: "RoutesGenerated",
+            Value: msg.count ?? 0,
+            Unit: "Count",
+            Timestamp: ts,
+          });
+          break;
+        case "started":
+          metricData.push({
+            MetricName: "RouteStarted",
+            Value: 1,
+            Unit: "Count",
+            Timestamp: ts,
+          });
+          break;
+        case "finished":
+          metricData.push({
+            MetricName: "RouteFinished",
+            Value: 1,
+            Unit: "Count",
+            Timestamp: ts,
+          });
+          if (msg.actualDuration != null) {
+            metricData.push({
+              MetricName: "ActualDuration",
+              Value: msg.actualDuration,
+              Unit: "Seconds",
+              Timestamp: ts,
+            });
+          }
+          break;
+        default:
+          console.warn("[metrics-processor] unknown event", msg);
+      }
+    } catch (err) {
+      console.error("[metrics-processor] invalid message", err);
+    }
+  }
+
+  if (metricData.length) {
+    await cw.send(
+      new PutMetricDataCommand({ Namespace: namespace, MetricData: metricData })
+    );
+  }
 };


### PR DESCRIPTION
## Summary
- send route generation metrics from worker to SQS
- publish metrics to CloudWatch via metrics processor
- provision environment, IAM permissions and tests for metrics

## Testing
- `npm run test:unit` in `src/backend`
- `npm run test:unit` in `infrastructure`


------
https://chatgpt.com/codex/tasks/task_e_68b87f828b20832f983553fe3fd4bc49