### PR TITLE
chore: add ESLint flat config for frontend

### DIFF
--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -1,0 +1,32 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  reactHooks.configs['recommended-latest'],
+  reactRefresh.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx,js,jsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    settings: {
+      react: { version: 'detect' },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      'no-empty': 'off',
+      'react-refresh/only-export-components': 'off',
+      'no-irregular-whitespace': 'off',
+    },
+  },
+);


### PR DESCRIPTION
## Summary
- add ESLint flat config for frontend project with TypeScript and React plugins
- disable several strict rules to accommodate existing codebase

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b896c7a038832f9863444287961fc0