### PR TITLE
Add NONE data source and mutation resolvers to AppSync

### DIFF
--- a/infrastructure/lib/stacks/appsync-stack.test.ts
+++ b/infrastructure/lib/stacks/appsync-stack.test.ts
@@ -59,4 +59,22 @@ describe("AppSyncStack", () => {
       });
     }
   });
+
+  test("creates resolvers for mutations", () => {
+    const mutations = [
+      "publishRoutesGenerated",
+      "publishFavouriteSaved",
+      "publishFavouriteDeleted",
+      "publishRouteStarted",
+      "publishRouteFinished",
+    ];
+
+    mutations.forEach((field) => {
+      template.hasResourceProperties("AWS::AppSync::Resolver", {
+        TypeName: "Mutation",
+        FieldName: field,
+        DataSourceName: "NoneDS",
+      });
+    });
+  });
 });

--- a/infrastructure/lib/stacks/appsync-stack.ts
+++ b/infrastructure/lib/stacks/appsync-stack.ts
@@ -5,6 +5,7 @@ import {
   AuthorizationType,
   FieldLogLevel,
   SchemaFile,
+  MappingTemplate,
 } from "aws-cdk-lib/aws-appsync";
 import { IUserPool } from "aws-cdk-lib/aws-cognito";
 import * as path from "path";
@@ -35,6 +36,29 @@ export class AppSyncStack extends cdk.Stack {
         },
       },
     });
+
+    const noneDs = this.api.addNoneDataSource("NoneDS");
+
+    const mutations = [
+      "publishRoutesGenerated",
+      "publishFavouriteSaved",
+      "publishFavouriteDeleted",
+      "publishRouteStarted",
+      "publishRouteFinished",
+    ];
+
+    mutations.forEach((field) =>
+      noneDs.createResolver(field, {
+        typeName: "Mutation",
+        fieldName: field,
+        requestMappingTemplate: MappingTemplate.fromString(
+          "$util.toJson($context.arguments)"
+        ),
+        responseMappingTemplate: MappingTemplate.fromString(
+          "$util.toJson($context.arguments)"
+        ),
+      })
+    );
 
     new cdk.CfnOutput(this, "AppSyncUrl", {
       value: this.api.graphqlUrl,


### PR DESCRIPTION
## Summary
- add NONE data source and echoing resolvers for publish mutations
- test resolvers are synthesized

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68b899c81580832f8c3ea0d902f2c0b4