### PR TITLE
ci: add frontend lint job to dev deploy workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -54,11 +54,28 @@ jobs:
         working-directory: infrastructure
         run: npm run test:unit
 
+  lint-frontend:
+    name: Lint frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: src/frontend/package-lock.json
+      - name: Install deps (frontend)
+        working-directory: src/frontend
+        run: npm ci
+      - name: Run lint
+        working-directory: src/frontend
+        run: npm run lint
+
   deploy:
     name: Deploy to dev
     environment: dev
     runs-on: ubuntu-latest
-    needs: [test-backend, test-infra]
+    needs: [test-backend, test-infra, lint-frontend]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add frontend lint job to CI dev workflow
- ensure deploy waits for frontend lint

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89b4cfc14832fa74d55ff1d823034