### PR TITLE
Allow AppSync access for favorite routes

### DIFF
--- a/infrastructure/lib/stacks/compute-stack.ts
+++ b/infrastructure/lib/stacks/compute-stack.ts
@@ -133,6 +133,12 @@ export class ComputeStack extends cdk.Stack {
         resources: [props.userStateTable.tableArn],
       })
     );
+    favoriteRoutes.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["appsync:GraphQL"],
+        resources: ["*"], // or the specific API ARN
+      })
+    );
 
     // 4) ProfileRoutes → GET/PUT /profile
     const profileRoutes = new HttpLambda(this, "ProfileRoutes", {


### PR DESCRIPTION
## Summary
- allow favorite routes Lambda to perform AppSync GraphQL operations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68b89e5bf124832fa5670cf9df77e4ec