### PR TITLE
docs: clarify circular route segments

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -162,7 +162,10 @@ async function snapToRoad(pt: { lat: number; lng: number }, apiKey: string) {
   }
 }
 
-/** Compute an 8‑segment loop */
+/**
+ * Compute a multi-segment loop.
+ * Typical segment counts are 4, 6, or 8.
+ */
 async function computeCircularRoute(
   origin: { lat: number; lng: number },
   dKm: number,


### PR DESCRIPTION
## Summary
- clarify that `computeCircularRoute` supports configurable segment counts
- document typical segment counts (4, 6, 8) for guidance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:unit`
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b89ed6b4ac832fab5829f5a1d1bbcf