### PR TITLE
feat: enhance circular route generation

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -163,40 +163,83 @@ async function snapToRoad(pt: { lat: number; lng: number }, apiKey: string) {
 }
 
 /**
- * Compute a multi-segment loop.
- * Typical segment counts are 4, 6, or 8.
+ * Compute a multi-segment loop starting/ending at the origin.
+ * Supports arbitrary segment counts (typical: 4, 6, 8).
+ * Each segment is attempted with a full detour, then a half-radius detour,
+ * and finally a direct leg to the origin if needed. If fewer than half the
+ * segments succeed the route is discarded.
  */
 async function computeCircularRoute(
   origin: { lat: number; lng: number },
   dKm: number,
   segments: number,
-  apiKey: string
+  apiKey: string,
+  startBearing = 0,
+  radiusMultiplier = 1
 ) {
   console.info("[computeCircularRoute] start", origin, "dKm=", dKm);
-  const radius = dKm / (2 * Math.PI),
-    pts = [];
-  // build & snap waypoints
+  const baseRadius = (dKm / (2 * Math.PI)) * radiusMultiplier;
+  const step = 360 / segments;
+
+  // build & snap waypoints at full radius
+  const waypoints = [];
   for (let i = 0; i < segments; i++) {
     const raw = offsetCoordinate(
       origin.lat,
       origin.lng,
-      radius,
-      (360 / segments) * i
+      baseRadius,
+      startBearing + step * i
     );
-    pts.push(await snapToRoad(raw, apiKey));
+    const snapped = await snapToRoad(raw, apiKey);
+    const pt =
+      snapped.lat === origin.lat && snapped.lng === origin.lng ? raw : snapped;
+    waypoints.push(pt);
   }
-  // stitch legs
+
+  // stitch legs with per-segment recovery
   let totalDist = 0,
     totalDur = 0,
-    encoded: string | undefined;
+    encoded: string | undefined,
+    prev = origin,
+    success = 0;
   for (let i = 0; i < segments; i++) {
-    const a = pts[i],
-      b = pts[(i + 1) % segments];
-    const legs = await computeRoutes(a, b, apiKey);
-    const leg = legs[0];
+    const angle = startBearing + step * i;
+    const primary = waypoints[i];
+    const halfRaw = offsetCoordinate(origin.lat, origin.lng, baseRadius * 0.5, angle);
+    const halfSnap = await snapToRoad(halfRaw, apiKey);
+    const half =
+      halfSnap.lat === origin.lat && halfSnap.lng === origin.lng ? halfRaw : halfSnap;
+    const candidates = [primary, half, origin];
+    let leg: any = null,
+      used = primary;
+    for (let attempt = 0; attempt < candidates.length; attempt++) {
+      const dest = candidates[attempt];
+      const legs = await computeRoutes(prev, dest, apiKey);
+      const cand = legs[0];
+      if (cand?.encoded) {
+        leg = cand;
+        used = dest;
+        if (attempt > 0)
+          console.warn(
+            `[computeCircularRoute] segment ${i} fallback attempt ${attempt}`
+          );
+        break;
+      }
+    }
     if (!leg) {
-      console.warn("[computeCircularRoute] missing leg at segment", i);
-      return null;
+      console.warn(`[computeCircularRoute] segment ${i} failed`);
+      // try to close directly to origin and exit
+      const legs = await computeRoutes(prev, origin, apiKey);
+      const closeLeg = legs[0];
+      if (closeLeg?.encoded) {
+        console.warn(
+          `[computeCircularRoute] segment ${i} forced direct origin to close`
+        );
+        leg = closeLeg;
+        used = origin;
+      } else {
+        break;
+      }
     }
     totalDist += leg.distanceMeters;
     totalDur += leg.durationSeconds;
@@ -207,8 +250,31 @@ async function computeCircularRoute(
     } else {
       encoded = leg.encoded;
     }
+    prev = used;
+    success++;
+    if (prev.lat === origin.lat && prev.lng === origin.lng) break;
   }
-  if (!encoded) return null;
+
+  // ensure loop closure
+  if (prev.lat !== origin.lat || prev.lng !== origin.lng) {
+    const legs = await computeRoutes(prev, origin, apiKey);
+    const leg = legs[0];
+    if (leg?.encoded) {
+      console.warn("[computeCircularRoute] closing loop to origin");
+      totalDist += leg.distanceMeters;
+      totalDur += leg.durationSeconds;
+      if (encoded) {
+        const c1 = new Path(encoded).Coordinates;
+        const c2 = new Path(leg.encoded).Coordinates.slice(1);
+        encoded = Path.fromCoordinates([...c1, ...c2]).Encoded;
+      } else {
+        encoded = leg.encoded;
+      }
+      success++;
+    }
+  }
+
+  if (!encoded || success < segments / 2) return null;
   return { distanceMeters: totalDist, durationSeconds: totalDur, encoded };
 }
 
@@ -290,12 +356,28 @@ export const handler: SQSHandler = async (event) => {
           encoded: string;
         } | null = null;
         if (roundTrip && circle) {
-          leg = await computeCircularRoute(oCoords, distanceKm!, 4, key);
+          // try multiple circular configurations (segments, radius, bearing)
+          const segOptions = [4, 6, 8];
+          const radiusOpts = [1, 0.75, 0.5];
+          outer: for (const segs of segOptions) {
+            for (const rMul of radiusOpts) {
+              const bearing = Math.random() * 360;
+              leg = await computeCircularRoute(
+                oCoords,
+                distanceKm!,
+                segs,
+                key,
+                bearing,
+                rMul
+              );
+              if (leg) break outer;
+            }
+          }
           if (!leg) {
             console.warn(
               "[handler] circular failed, fallback to simple round-trip"
             );
-            // sacamos dos legs: ida y vuelta
+            // fall back to two legs: out and back
             const bearing = Math.random() * 360;
             const half = distanceKm! / 2;
             const rawDest = offsetCoordinate(


### PR DESCRIPTION
## Summary
- add multi-attempt circular route generation with varying segments, radii and bearings
- retry circular segments with smaller detours or direct legs before aborting
- adjust circular route test to accommodate new logic

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68b8a1baaf84832fa37bda2ba18adc65