### PR TITLE
refactor: use shared UUID value object in route event

### DIFF
--- a/src/backend/src/routes/domain/events/route-requested.ts
+++ b/src/backend/src/routes/domain/events/route-requested.ts
@@ -1,5 +1,5 @@
 import { DomainEvent } from "../../../shared/domain/events/domain-event";
-import { UUID } from "../value-objects/uuid-value-object";
+import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
 
 export interface RouteRequestedProps {
   readonly routeId: UUID;


### PR DESCRIPTION
## Summary
- refactor RouteRequestedEvent to use shared UUID value object

## Testing
- `npm run build` (fails: Type 'Uint8Array' is not generic, plus other TypeScript errors)
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68bc90a2c840832f9d1ff8fb60fbe886