### PR TITLE
refactor: use UUID for job-based route lookup

### DIFF
--- a/src/backend/src/routes/domain/repositories/route-repository.ts
+++ b/src/backend/src/routes/domain/repositories/route-repository.ts
@@ -5,6 +5,6 @@ export interface RouteRepository {
   save(route: Route): Promise<void>;
   findById(id: UUID): Promise<Route | null>;
   findAll(): Promise<Route[]>;
-  findByJobId(jobId: string): Promise<Route[]>;
+  findByJobId(jobId: UUID): Promise<Route[]>;
   remove(id: UUID): Promise<void>;
 }

--- a/src/backend/src/routes/infrastructure/dynamodb/dynamo-route-repository.test.ts
+++ b/src/backend/src/routes/infrastructure/dynamodb/dynamo-route-repository.test.ts
@@ -119,13 +119,13 @@ describe("DynamoRouteRepository", () => {
   });
 
   it("findByJobId queries using GSI2", async () => {
-    const routeId = UUID.generate().Value;
-    const jobId = UUID.generate().Value;
+    const routeId = UUID.generate();
+    const jobId = UUID.generate();
     const returned = {
       Items: [
         {
-          routeId: { S: routeId },
-          jobId: { S: jobId },
+          routeId: { S: routeId.Value },
+          jobId: { S: jobId.Value },
           description: { S: "d" },
           status: { S: RouteStatus.Requested },
         },
@@ -139,10 +139,10 @@ describe("DynamoRouteRepository", () => {
       TableName: tableName,
       IndexName: "GSI2",
       KeyConditionExpression: "jobId = :job",
-      ExpressionAttributeValues: { ":job": { S: jobId } },
+      ExpressionAttributeValues: { ":job": { S: jobId.Value } },
     });
     expect(res).toHaveLength(1);
-    expect(res[0].jobId?.Value).toBe(jobId);
+    expect(res[0].jobId?.Value).toBe(jobId.Value);
     expect(res[0].description).toBe("d");
   });
 });

--- a/src/backend/src/routes/infrastructure/dynamodb/dynamo-route-repository.ts
+++ b/src/backend/src/routes/infrastructure/dynamodb/dynamo-route-repository.ts
@@ -88,14 +88,14 @@ export class DynamoRouteRepository implements RouteRepository {
     );
   }
 
-  async findByJobId(jobId: string): Promise<Route[]> {
+  async findByJobId(jobId: UUID): Promise<Route[]> {
     const res = await this.client.send(
       new QueryCommand({
         TableName: this.tableName,
         IndexName: "GSI2",
         KeyConditionExpression: "jobId = :job",
         ExpressionAttributeValues: {
-          ":job": { S: jobId },
+          ":job": { S: jobId.Value },
         },
       })
     );

--- a/src/backend/src/routes/infrastructure/in-memory/in-memory-route-repository.test.ts
+++ b/src/backend/src/routes/infrastructure/in-memory/in-memory-route-repository.test.ts
@@ -78,7 +78,7 @@ describe("InMemoryRouteRepository", () => {
     await repo.save(r1);
     await repo.save(r2);
 
-    const res = await repo.findByJobId(jobId.Value);
+    const res = await repo.findByJobId(jobId);
     expect(res.map((r) => r.routeId.Value)).toEqual([
       r1.routeId.Value,
       r2.routeId.Value,

--- a/src/backend/src/routes/infrastructure/in-memory/in-memory-route-repository.ts
+++ b/src/backend/src/routes/infrastructure/in-memory/in-memory-route-repository.ts
@@ -17,8 +17,8 @@ export class InMemoryRouteRepository implements RouteRepository {
     return Array.from(this.routes.values());
   }
 
-  async findByJobId(jobId: string): Promise<Route[]> {
-    return Array.from(this.routes.values()).filter((r) => r.jobId?.Value === jobId);
+  async findByJobId(jobId: UUID): Promise<Route[]> {
+    return Array.from(this.routes.values()).filter((r) => r.jobId?.equals(jobId));
   }
   
   async remove(id: UUID): Promise<void> {

--- a/src/backend/src/routes/interfaces/http/page-router.test.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.test.ts
@@ -208,7 +208,7 @@ describe("page router list routes by jobId", () => {
       ...baseEvent,
       pathParameters: { jobId: jobId.Value },
     });
-    expect(mockFindByJobId).toHaveBeenCalledWith(jobId.Value);
+    expect(mockFindByJobId).toHaveBeenCalledWith(jobId);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual([
       {

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -112,7 +112,9 @@ export const handler = async (
       };
     }
     try {
-      const list = await routeRepository.findByJobId(jobId);
+      const list = await routeRepository.findByJobId(
+        UUID.fromString(jobId)
+      );
       return {
         statusCode: 200,
         headers: corsHeaders,


### PR DESCRIPTION
## Summary
- refactor RouteRepository.findByJobId to accept a UUID instead of a string
- adjust Dynamo and in-memory route repositories and HTTP handler
- update unit tests for new UUID signature

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc90a41320832fb2a1f43e4f0a2d1e