### PR TITLE
feat: add describe route use case

### DIFF
--- a/src/backend/src/routes/application/use-cases/describe-route.ts
+++ b/src/backend/src/routes/application/use-cases/describe-route.ts
@@ -1,0 +1,28 @@
+import { RouteRepository } from "../../domain/repositories/route-repository";
+import { Route } from "../../domain/entities/route-entity";
+import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
+import { MapProvider } from "../../domain/services/map-provider";
+import { describeRoute } from "../../handlers/describe-route";
+
+export class DescribeRouteUseCase {
+  constructor(private repository: RouteRepository) {}
+
+  async execute(id: UUID, mapProvider: MapProvider): Promise<Route | null> {
+    const route = await this.repository.findById(id);
+    if (!route) return null;
+
+    if (!route.description && route.path) {
+      try {
+        const desc = await describeRoute(route.path.Encoded, mapProvider);
+        if (desc) {
+          route.description = desc;
+          await this.repository.save(route);
+        }
+      } catch (err) {
+        console.warn("describeRoute failed:", err);
+      }
+    }
+
+    return route;
+  }
+}

--- a/src/backend/src/routes/application/use-cases/describe-route.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/describe-route.usecase.test.ts
@@ -1,0 +1,43 @@
+import { DescribeRouteUseCase } from './describe-route';
+import { RouteRepository } from '../../domain/repositories/route-repository';
+import { Route } from '../../domain/entities/route-entity';
+import { UUID } from '../../../shared/domain/value-objects/uuid-value-object';
+import { MapProvider } from '../../domain/services/map-provider';
+import { Path } from '../../domain/value-objects/path-value-object';
+import { LatLng } from '../../domain/value-objects/lat-lng-value-object';
+import { RouteStatus } from '../../domain/value-objects/route-status';
+import { describeRoute } from '../../handlers/describe-route';
+
+jest.mock('../../handlers/describe-route', () => ({
+  describeRoute: jest.fn().mockResolvedValue('generated description'),
+}));
+
+describe('DescribeRouteUseCase', () => {
+  it('generates and saves description when missing', async () => {
+    const routeId = UUID.generate();
+    const path = Path.fromCoordinates([
+      LatLng.fromNumbers(0, 0),
+      LatLng.fromNumbers(1, 1),
+    ]);
+    const route = Route.rehydrate({ routeId, path, status: RouteStatus.Generated });
+    const repo: RouteRepository = {
+      findById: jest.fn().mockResolvedValue(route),
+      save: jest.fn(),
+      findAll: jest.fn(),
+      findByJobId: jest.fn(),
+      remove: jest.fn(),
+    } as any;
+    const mapProvider: MapProvider = {
+      getCityName: jest.fn().mockResolvedValue('City'),
+    };
+    const useCase = new DescribeRouteUseCase(repo);
+
+    const result = await useCase.execute(routeId, mapProvider);
+
+    expect(repo.findById).toHaveBeenCalledWith(routeId);
+    expect(result).toBe(route);
+    expect(result?.description).toBe('generated description');
+    expect(repo.save).toHaveBeenCalledWith(route);
+    expect((describeRoute as jest.Mock).mock.calls[0][0]).toBe(path.Encoded);
+  });
+});


### PR DESCRIPTION
## Summary
- add DescribeRouteUseCase to generate and persist route descriptions
- use DescribeRouteUseCase in page router when fetching a route
- cover DescribeRouteUseCase with unit tests

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68bc90a4a76c832fa7e01c9d91dc4651