### PR TITLE
refactor: introduce event dispatcher interface

### DIFF
--- a/src/backend/src/routes/application/use-cases/request-routes.ts
+++ b/src/backend/src/routes/application/use-cases/request-routes.ts
@@ -1,13 +1,13 @@
 import { RouteRepository } from "../../domain/repositories/route-repository";
 import { Route, RouteProps } from "../../domain/entities/route-entity";
-import { InMemoryEventDispatcher } from "../../../shared/domain/events/event-dispatcher";
+import { EventDispatcher } from "../../../shared/domain/events/event-dispatcher";
 
 export interface RequestRoutesInput extends Omit<RouteProps, "status"> {}
 
 export class RequestRoutesUseCase {
   constructor(
     private repository: RouteRepository,
-    private dispatcher: InMemoryEventDispatcher
+    private dispatcher: EventDispatcher
   ) {}
 
   async execute(input: RequestRoutesInput): Promise<Route> {

--- a/src/backend/src/routes/application/use-cases/request-routes.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/request-routes.usecase.test.ts
@@ -3,14 +3,17 @@ import { RouteRepository } from "../../domain/repositories/route-repository";
 import { Route } from "../../domain/entities/route-entity";
 import { RouteStatus } from "../../domain/value-objects/route-status";
 import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
-import { InMemoryEventDispatcher } from "../../../shared/domain/events/event-dispatcher";
+import {
+  EventDispatcher,
+  InMemoryEventDispatcher,
+} from "../../../shared/domain/events/event-dispatcher";
 import { RouteRequestedEvent } from "../../domain/events/route-requested";
 
 describe("RequestRoutesUseCase", () => {
   it("saves, returns a Route instance and publishes events", async () => {
     const save = jest.fn();
     const repo: RouteRepository = { save } as any;
-    const dispatcher = new InMemoryEventDispatcher();
+    const dispatcher: EventDispatcher = new InMemoryEventDispatcher();
     const handler = jest.fn();
     dispatcher.subscribe("RouteRequested", handler);
     const useCase = new RequestRoutesUseCase(repo, dispatcher);

--- a/src/backend/src/routes/interfaces/telemetry/route-events-subscriber.ts
+++ b/src/backend/src/routes/interfaces/telemetry/route-events-subscriber.ts
@@ -1,8 +1,8 @@
-import { InMemoryEventDispatcher } from "../../../shared/domain/events/event-dispatcher";
+import { EventDispatcher } from "../../../shared/domain/events/event-dispatcher";
 import { RouteRequestedEvent } from "../../domain/events/route-requested";
 import { RouteGeneratedEvent } from "../../domain/events/route-generated";
 
-export function registerTelemetrySubscribers(dispatcher: InMemoryEventDispatcher): void {
+export function registerTelemetrySubscribers(dispatcher: EventDispatcher): void {
   dispatcher.subscribe("RouteRequested", (event: RouteRequestedEvent) => {
     console.log("Telemetry: route requested", event.routeId.Value);
   });

--- a/src/backend/src/shared/domain/events/event-dispatcher.ts
+++ b/src/backend/src/shared/domain/events/event-dispatcher.ts
@@ -1,11 +1,25 @@
 import { DomainEvent } from "./domain-event";
 
-type EventHandler<T extends DomainEvent = DomainEvent> = (event: T) => void | Promise<void>;
+export type EventHandler<T extends DomainEvent = DomainEvent> = (
+  event: T
+) => void | Promise<void>;
 
-export class InMemoryEventDispatcher {
+export interface EventDispatcher {
+  subscribe<T extends DomainEvent>(
+    eventName: string,
+    handler: EventHandler<T>
+  ): void;
+  publish(event: DomainEvent): Promise<void>;
+  publishAll(events: DomainEvent[]): Promise<void>;
+}
+
+export class InMemoryEventDispatcher implements EventDispatcher {
   private handlers: { [eventName: string]: EventHandler[] } = {};
 
-  subscribe<T extends DomainEvent>(eventName: string, handler: EventHandler<T>): void {
+  subscribe<T extends DomainEvent>(
+    eventName: string,
+    handler: EventHandler<T>
+  ): void {
     if (!this.handlers[eventName]) {
       this.handlers[eventName] = [];
     }


### PR DESCRIPTION
## Summary
- add EventDispatcher interface and in-memory implementation
- use EventDispatcher in RequestRoutesUseCase and subscribers
- update unit tests for new interface

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68bc90a63f5c832fb0bb4015f4b670d9