### PR TITLE
feat(routes): add route start and finish use cases

### DIFF
--- a/src/backend/src/routes/application/use-cases/finish-route.ts
+++ b/src/backend/src/routes/application/use-cases/finish-route.ts
@@ -1,0 +1,36 @@
+import { RouteRepository } from "../../domain/repositories/route-repository";
+import { EventDispatcher } from "../../../shared/domain/events/event-dispatcher";
+import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
+import { RouteFinishedEvent } from "../../domain/events/route-finished";
+import { Route } from "../../domain/entities/route-entity";
+
+export interface FinishRouteInput {
+  readonly routeId: UUID;
+  readonly email: string;
+  readonly timestamp: number;
+  readonly actualDuration?: number;
+}
+
+export class FinishRouteUseCase {
+  constructor(
+    private repository: RouteRepository,
+    private dispatcher: EventDispatcher
+  ) {}
+
+  async execute(input: FinishRouteInput): Promise<Route | null> {
+    const route = await this.repository.findById(input.routeId);
+    if (!route) return null;
+    route.finish();
+    await this.repository.save(route);
+    await this.dispatcher.publishAll([
+      ...route.pullEvents(),
+      new RouteFinishedEvent({
+        route,
+        email: input.email,
+        timestamp: input.timestamp,
+        actualDuration: input.actualDuration,
+      }),
+    ]);
+    return route;
+  }
+}

--- a/src/backend/src/routes/application/use-cases/finish-route.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/finish-route.usecase.test.ts
@@ -1,0 +1,63 @@
+import { FinishRouteUseCase } from "./finish-route";
+import { RouteRepository } from "../../domain/repositories/route-repository";
+import { Route } from "../../domain/entities/route-entity";
+import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
+import {
+  EventDispatcher,
+  InMemoryEventDispatcher,
+} from "../../../shared/domain/events/event-dispatcher";
+import { RouteFinishedEvent } from "../../domain/events/route-finished";
+import { DistanceKm } from "../../domain/value-objects/distance-value-object";
+import { Duration } from "../../domain/value-objects/duration-value-object";
+import { Path } from "../../domain/value-objects/path-value-object";
+import { LatLng } from "../../domain/value-objects/lat-lng-value-object";
+import { RouteStatus } from "../../domain/value-objects/route-status";
+
+describe("FinishRouteUseCase", () => {
+  it("finishes route, saves and publishes event", async () => {
+    const route = Route.request({ routeId: UUID.generate() });
+    route.generate(
+      new DistanceKm(1),
+      new Duration(60),
+      Path.fromCoordinates([
+        LatLng.fromNumbers(0, 0),
+        LatLng.fromNumbers(1, 1),
+      ])
+    );
+    route.start();
+    const findById = jest.fn().mockResolvedValue(route);
+    const save = jest.fn();
+    const repo: RouteRepository = { findById, save } as any;
+    const dispatcher: EventDispatcher = new InMemoryEventDispatcher();
+    const handler = jest.fn();
+    dispatcher.subscribe("RouteFinished", handler);
+    const useCase = new FinishRouteUseCase(repo, dispatcher);
+    const ts = Date.now();
+
+    const result = await useCase.execute({
+      routeId: route.routeId,
+      email: "a@test",
+      timestamp: ts,
+      actualDuration: 120,
+    });
+
+    expect(findById).toHaveBeenCalledWith(route.routeId);
+    expect(save).toHaveBeenCalledWith(route);
+    expect(result?.status).toBe(RouteStatus.Finished);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toBeInstanceOf(RouteFinishedEvent);
+  });
+
+  it("returns null when route not found", async () => {
+    const findById = jest.fn().mockResolvedValue(null);
+    const repo: RouteRepository = { findById } as any;
+    const dispatcher: EventDispatcher = new InMemoryEventDispatcher();
+    const useCase = new FinishRouteUseCase(repo, dispatcher);
+    const res = await useCase.execute({
+      routeId: UUID.generate(),
+      email: "b@test",
+      timestamp: Date.now(),
+    });
+    expect(res).toBeNull();
+  });
+});

--- a/src/backend/src/routes/application/use-cases/start-route.ts
+++ b/src/backend/src/routes/application/use-cases/start-route.ts
@@ -1,0 +1,34 @@
+import { RouteRepository } from "../../domain/repositories/route-repository";
+import { EventDispatcher } from "../../../shared/domain/events/event-dispatcher";
+import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
+import { RouteStartedEvent } from "../../domain/events/route-started";
+import { Route } from "../../domain/entities/route-entity";
+
+export interface StartRouteInput {
+  readonly routeId: UUID;
+  readonly email: string;
+  readonly timestamp: number;
+}
+
+export class StartRouteUseCase {
+  constructor(
+    private repository: RouteRepository,
+    private dispatcher: EventDispatcher
+  ) {}
+
+  async execute(input: StartRouteInput): Promise<Route | null> {
+    const route = await this.repository.findById(input.routeId);
+    if (!route) return null;
+    route.start();
+    await this.repository.save(route);
+    await this.dispatcher.publishAll([
+      ...route.pullEvents(),
+      new RouteStartedEvent({
+        route,
+        email: input.email,
+        timestamp: input.timestamp,
+      }),
+    ]);
+    return route;
+  }
+}

--- a/src/backend/src/routes/application/use-cases/start-route.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/start-route.usecase.test.ts
@@ -1,0 +1,61 @@
+import { StartRouteUseCase } from "./start-route";
+import { RouteRepository } from "../../domain/repositories/route-repository";
+import { Route } from "../../domain/entities/route-entity";
+import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
+import {
+  EventDispatcher,
+  InMemoryEventDispatcher,
+} from "../../../shared/domain/events/event-dispatcher";
+import { RouteStartedEvent } from "../../domain/events/route-started";
+import { DistanceKm } from "../../domain/value-objects/distance-value-object";
+import { Duration } from "../../domain/value-objects/duration-value-object";
+import { Path } from "../../domain/value-objects/path-value-object";
+import { LatLng } from "../../domain/value-objects/lat-lng-value-object";
+import { RouteStatus } from "../../domain/value-objects/route-status";
+
+describe("StartRouteUseCase", () => {
+  it("starts route, saves and publishes event", async () => {
+    const route = Route.request({ routeId: UUID.generate() });
+    route.generate(
+      new DistanceKm(1),
+      new Duration(60),
+      Path.fromCoordinates([
+        LatLng.fromNumbers(0, 0),
+        LatLng.fromNumbers(1, 1),
+      ])
+    );
+    const findById = jest.fn().mockResolvedValue(route);
+    const save = jest.fn();
+    const repo: RouteRepository = { findById, save } as any;
+    const dispatcher: EventDispatcher = new InMemoryEventDispatcher();
+    const handler = jest.fn();
+    dispatcher.subscribe("RouteStarted", handler);
+    const useCase = new StartRouteUseCase(repo, dispatcher);
+    const ts = Date.now();
+
+    const result = await useCase.execute({
+      routeId: route.routeId,
+      email: "a@test",
+      timestamp: ts,
+    });
+
+    expect(findById).toHaveBeenCalledWith(route.routeId);
+    expect(save).toHaveBeenCalledWith(route);
+    expect(result?.status).toBe(RouteStatus.Started);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toBeInstanceOf(RouteStartedEvent);
+  });
+
+  it("returns null when route not found", async () => {
+    const findById = jest.fn().mockResolvedValue(null);
+    const repo: RouteRepository = { findById } as any;
+    const dispatcher: EventDispatcher = new InMemoryEventDispatcher();
+    const useCase = new StartRouteUseCase(repo, dispatcher);
+    const res = await useCase.execute({
+      routeId: UUID.generate(),
+      email: "b@test",
+      timestamp: Date.now(),
+    });
+    expect(res).toBeNull();
+  });
+});

--- a/src/backend/src/routes/domain/events/route-finished.ts
+++ b/src/backend/src/routes/domain/events/route-finished.ts
@@ -1,0 +1,25 @@
+import { DomainEvent } from "../../../shared/domain/events/domain-event";
+import { Route } from "../entities/route-entity";
+
+export interface RouteFinishedProps {
+  readonly route: Route;
+  readonly email: string;
+  readonly timestamp: number;
+  readonly actualDuration?: number;
+}
+
+export class RouteFinishedEvent extends DomainEvent {
+  readonly eventName = "RouteFinished";
+  readonly route: Route;
+  readonly email: string;
+  readonly timestamp: number;
+  readonly actualDuration?: number;
+
+  constructor(props: RouteFinishedProps) {
+    super();
+    this.route = props.route;
+    this.email = props.email;
+    this.timestamp = props.timestamp;
+    this.actualDuration = props.actualDuration;
+  }
+}

--- a/src/backend/src/routes/domain/events/route-started.ts
+++ b/src/backend/src/routes/domain/events/route-started.ts
@@ -1,0 +1,22 @@
+import { DomainEvent } from "../../../shared/domain/events/domain-event";
+import { Route } from "../entities/route-entity";
+
+export interface RouteStartedProps {
+  readonly route: Route;
+  readonly email: string;
+  readonly timestamp: number;
+}
+
+export class RouteStartedEvent extends DomainEvent {
+  readonly eventName = "RouteStarted";
+  readonly route: Route;
+  readonly email: string;
+  readonly timestamp: number;
+
+  constructor(props: RouteStartedProps) {
+    super();
+    this.route = props.route;
+    this.email = props.email;
+    this.timestamp = props.timestamp;
+  }
+}

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -7,10 +7,17 @@ import { publishRouteStarted, publishRouteFinished } from "../appsync-client";
 import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
 import { ListRoutesUseCase } from "../../application/use-cases/list-routes";
 import { DescribeRouteUseCase } from "../../application/use-cases/describe-route";
-import { GetRouteDetailsUseCase } from "../../application/use-cases/get-route-details";
+import { StartRouteUseCase } from "../../application/use-cases/start-route";
+import { FinishRouteUseCase } from "../../application/use-cases/finish-route";
 import { corsHeaders } from "../../../http/cors";
 import { getGoogleKey } from "../shared/utils";
 import { GoogleMapsProvider } from "../../infrastructure/google-maps/google-maps-provider";
+import {
+  EventDispatcher,
+  InMemoryEventDispatcher,
+} from "../../../shared/domain/events/event-dispatcher";
+import { RouteStartedEvent } from "../../domain/events/route-started";
+import { RouteFinishedEvent } from "../../domain/events/route-finished";
 
 const dynamo = new DynamoDBClient({});
 const sqs = new SQSClient({});
@@ -22,9 +29,64 @@ const userActivityRepository = new DynamoUserActivityRepository(
   dynamo,
   process.env.USER_STATE_TABLE!
 );
+const dispatcher: EventDispatcher = new InMemoryEventDispatcher();
+dispatcher.subscribe("RouteStarted", async (event: RouteStartedEvent) => {
+  await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: process.env.METRICS_QUEUE!,
+      MessageBody: JSON.stringify({
+        event: "started",
+        routeId: event.route.routeId.Value,
+        email: event.email,
+        timestamp: event.timestamp,
+      }),
+    })
+  );
+  try {
+    await publishRouteStarted(event.email, event.route.routeId.Value);
+  } catch (err) {
+    console.error("❌ Error publishing route started:", err);
+  }
+});
+dispatcher.subscribe("RouteFinished", async (event: RouteFinishedEvent) => {
+  await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: process.env.METRICS_QUEUE!,
+      MessageBody: JSON.stringify({
+        event: "finished",
+        routeId: event.route.routeId.Value,
+        email: event.email,
+        timestamp: event.timestamp,
+        ...(event.actualDuration != null
+          ? { actualDuration: event.actualDuration }
+          : {}),
+      }),
+    })
+  );
+  try {
+    await publishRouteFinished(
+      event.email,
+      event.route.routeId.Value,
+      JSON.stringify({
+        routeId: event.route.routeId.Value,
+        distanceKm: event.route.distanceKm?.Value,
+        duration: event.route.duration?.Value,
+        path: event.route.path?.Encoded,
+        description: event.route.description,
+        ...(event.actualDuration != null
+          ? { actualDuration: event.actualDuration }
+          : {}),
+      })
+    );
+  } catch (err) {
+    console.error("❌ Error publishing route finished:", err);
+  }
+});
+
 const listRoutes = new ListRoutesUseCase(routeRepository);
 const describeRouteUseCase = new DescribeRouteUseCase(routeRepository);
-const getRouteDetails = new GetRouteDetailsUseCase(routeRepository);
+const startRouteUseCase = new StartRouteUseCase(routeRepository, dispatcher);
+const finishRouteUseCase = new FinishRouteUseCase(routeRepository, dispatcher);
 
 export const handler = async (
   event: APIGatewayProxyEvent
@@ -166,24 +228,18 @@ export const handler = async (
 
     const ts = Date.now();
     await userActivityRepository.putRouteStart(email, routeId, ts);
-    await sqs.send(
-      new SendMessageCommand({
-        QueueUrl: process.env.METRICS_QUEUE!,
-        MessageBody: JSON.stringify({
-          event: "started",
-          routeId,
-          email,
-          timestamp: ts,
-        }),
-      })
-    );
-
-    try {
-      await publishRouteStarted(email, routeId);
-    } catch (err) {
-      console.error("❌ Error publishing route started:", err);
+    const started = await startRouteUseCase.execute({
+      routeId: UUID.fromString(routeId),
+      email,
+      timestamp: ts,
+    });
+    if (!started) {
+      return {
+        statusCode: 404,
+        headers: corsHeaders,
+        body: JSON.stringify({ error: "Not Found" }),
+      };
     }
-
     return { statusCode: 200, headers: corsHeaders, body: JSON.stringify({ ok: true }) };
   }
 
@@ -197,11 +253,6 @@ export const handler = async (
       };
     }
 
-    const route = await getRouteDetails.execute(UUID.fromString(routeId));
-    if (!route) {
-      return { statusCode: 404, headers: corsHeaders, body: JSON.stringify({ error: "Not Found" }) };
-    }
-
     const finishTs = Date.now();
     const startTs = await userActivityRepository.getRouteStart(email, routeId);
     if (startTs != null) {
@@ -212,35 +263,14 @@ export const handler = async (
       actualDurationMs != null
         ? Math.round(actualDurationMs / 1000)
         : undefined;
-
-    await sqs.send(
-      new SendMessageCommand({
-        QueueUrl: process.env.METRICS_QUEUE!,
-        MessageBody: JSON.stringify({
-          event: "finished",
-          routeId,
-          email,
-          timestamp: finishTs,
-          ...(actualDuration != null ? { actualDuration } : {}),
-        }),
-      })
-    );
-
-    try {
-      await publishRouteFinished(
-        email,
-        routeId,
-        JSON.stringify({
-          routeId: route.routeId.Value,
-          distanceKm: route.distanceKm?.Value,
-          duration: route.duration?.Value,
-          path: route.path?.Encoded,
-          description: route.description,
-          ...(actualDuration != null ? { actualDuration } : {}),
-        })
-      );
-    } catch (err) {
-      console.error("❌ Error publishing route finished:", err);
+    const route = await finishRouteUseCase.execute({
+      routeId: UUID.fromString(routeId),
+      email,
+      timestamp: finishTs,
+      actualDuration,
+    });
+    if (!route) {
+      return { statusCode: 404, headers: corsHeaders, body: JSON.stringify({ error: "Not Found" }) };
     }
 
     return {


### PR DESCRIPTION
## Summary
- add route started and finished domain events
- implement use cases to start and finish routes and dispatch events
- refactor page router to use new use cases

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68bcb5c0dc0c832fb5e2408f1c148b5d