### PR TITLE
feat: introduce route description service

### DIFF
--- a/src/backend/src/routes/application/use-cases/describe-route.ts
+++ b/src/backend/src/routes/application/use-cases/describe-route.ts
@@ -2,10 +2,13 @@ import { RouteRepository } from "../../domain/repositories/route-repository";
 import { Route } from "../../domain/entities/route-entity";
 import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
 import { MapProvider } from "../../domain/services/map-provider";
-import { describeRoute } from "../../handlers/describe-route";
+import { RouteDescriptionService } from "../../domain/services/route-description-service";
 
 export class DescribeRouteUseCase {
-  constructor(private repository: RouteRepository) {}
+  constructor(
+    private repository: RouteRepository,
+    private routeDescriptionService: RouteDescriptionService
+  ) {}
 
   async execute(id: UUID, mapProvider: MapProvider): Promise<Route | null> {
     const route = await this.repository.findById(id);
@@ -13,7 +16,10 @@ export class DescribeRouteUseCase {
 
     if (!route.description && route.path) {
       try {
-        const desc = await describeRoute(route.path.Encoded, mapProvider);
+        const desc = await this.routeDescriptionService.describe(
+          route.path.Encoded,
+          mapProvider
+        );
         if (desc) {
           route.description = desc;
           await this.repository.save(route);

--- a/src/backend/src/routes/application/use-cases/describe-route.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/describe-route.usecase.test.ts
@@ -6,11 +6,7 @@ import { MapProvider } from '../../domain/services/map-provider';
 import { Path } from '../../domain/value-objects/path-value-object';
 import { LatLng } from '../../domain/value-objects/lat-lng-value-object';
 import { RouteStatus } from '../../domain/value-objects/route-status';
-import { describeRoute } from '../../handlers/describe-route';
-
-jest.mock('../../handlers/describe-route', () => ({
-  describeRoute: jest.fn().mockResolvedValue('generated description'),
-}));
+import { RouteDescriptionService } from '../../domain/services/route-description-service';
 
 describe('DescribeRouteUseCase', () => {
   it('generates and saves description when missing', async () => {
@@ -30,7 +26,10 @@ describe('DescribeRouteUseCase', () => {
     const mapProvider: MapProvider = {
       getCityName: jest.fn().mockResolvedValue('City'),
     };
-    const useCase = new DescribeRouteUseCase(repo);
+    const service: RouteDescriptionService = {
+      describe: jest.fn().mockResolvedValue('generated description'),
+    };
+    const useCase = new DescribeRouteUseCase(repo, service);
 
     const result = await useCase.execute(routeId, mapProvider);
 
@@ -38,6 +37,6 @@ describe('DescribeRouteUseCase', () => {
     expect(result).toBe(route);
     expect(result?.description).toBe('generated description');
     expect(repo.save).toHaveBeenCalledWith(route);
-    expect((describeRoute as jest.Mock).mock.calls[0][0]).toBe(path.Encoded);
+    expect(service.describe).toHaveBeenCalledWith(path.Encoded, mapProvider);
   });
 });

--- a/src/backend/src/routes/domain/services/route-description-service.ts
+++ b/src/backend/src/routes/domain/services/route-description-service.ts
@@ -1,0 +1,5 @@
+import { MapProvider } from "./map-provider";
+
+export interface RouteDescriptionService {
+  describe(path: string, provider: MapProvider): Promise<string>;
+}

--- a/src/backend/src/routes/infrastructure/bedrock-route-description-service.test.ts
+++ b/src/backend/src/routes/infrastructure/bedrock-route-description-service.test.ts
@@ -1,0 +1,42 @@
+import polyline from '@mapbox/polyline';
+import { BedrockRouteDescriptionService } from './bedrock-route-description-service';
+import { MapProvider } from '../domain/services/map-provider';
+
+const sendMock = jest.fn();
+
+jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: jest.fn(() => ({ send: sendMock })),
+  InvokeModelCommand: jest.fn().mockImplementation((args) => ({ args })),
+}));
+
+describe('BedrockRouteDescriptionService', () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    sendMock.mockResolvedValue({
+      body: Buffer.from(
+        JSON.stringify({ content: [{ text: 'desc from bedrock' }] })
+      ),
+    });
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ current: { temperature_2m: 20 } }),
+    });
+  });
+
+  it('invokes bedrock and returns description', async () => {
+    const service = new BedrockRouteDescriptionService();
+    const path = polyline.encode([
+      [0, 0],
+      [1, 1],
+    ]);
+    const provider: MapProvider = {
+      getCityName: jest.fn().mockResolvedValue('TestCity'),
+    };
+
+    const result = await service.describe(path, provider);
+
+    expect(sendMock).toHaveBeenCalled();
+    expect(result).toBe('desc from bedrock');
+    expect(provider.getCityName).toHaveBeenCalled();
+  });
+});
+

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -7,6 +7,7 @@ import { publishRouteStarted, publishRouteFinished } from "../appsync-client";
 import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
 import { ListRoutesUseCase } from "../../application/use-cases/list-routes";
 import { DescribeRouteUseCase } from "../../application/use-cases/describe-route";
+import { BedrockRouteDescriptionService } from "../../infrastructure/bedrock-route-description-service";
 import { GetRouteDetailsUseCase } from "../../application/use-cases/get-route-details";
 import { corsHeaders } from "../../../http/cors";
 import { getGoogleKey } from "../shared/utils";
@@ -23,7 +24,11 @@ const userActivityRepository = new DynamoUserActivityRepository(
   process.env.USER_STATE_TABLE!
 );
 const listRoutes = new ListRoutesUseCase(routeRepository);
-const describeRouteUseCase = new DescribeRouteUseCase(routeRepository);
+const routeDescriptionService = new BedrockRouteDescriptionService();
+const describeRouteUseCase = new DescribeRouteUseCase(
+  routeRepository,
+  routeDescriptionService
+);
 const getRouteDetails = new GetRouteDetailsUseCase(routeRepository);
 
 export const handler = async (


### PR DESCRIPTION
## Summary
- define `RouteDescriptionService` domain interface for route text generation
- implement Bedrock-backed `BedrockRouteDescriptionService`
- refactor `DescribeRouteUseCase` and page router to use the new service
- update existing tests and add coverage for Bedrock service

## Testing
- `cd src/backend && npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68bcb5c708ac832f9f28b09d3f09214d