### PR TITLE
Allow DynamoDB endpoint override

### DIFF
--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -21,7 +21,9 @@ import {
 import { RouteStartedEvent } from "../../domain/events/route-started";
 import { RouteFinishedEvent } from "../../domain/events/route-finished";
 
-const dynamo = new DynamoDBClient({});
+const dynamo = new DynamoDBClient({
+  endpoint: process.env.AWS_ENDPOINT_URL_DYNAMODB,
+});
 const sqs = new SQSClient({});
 const routeRepository = new DynamoRouteRepository(
   dynamo,

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -10,7 +10,9 @@ import { publishRoutesGenerated } from "../appsync-client";
 import { fetchJson, getGoogleKey } from "../shared/utils";
 import { RouteGenerator } from "../../domain/services/route-generator";
 
-const dynamo = new DynamoDBClient({});
+const dynamo = new DynamoDBClient({
+  endpoint: process.env.AWS_ENDPOINT_URL_DYNAMODB,
+});
 const sqs = new SQSClient({});
 const repository = new DynamoRouteRepository(dynamo, process.env.ROUTES_TABLE!);
 const generator = new RouteGenerator(repository);

--- a/src/backend/src/users/interfaces/http/favourite-routes.ts
+++ b/src/backend/src/users/interfaces/http/favourite-routes.ts
@@ -9,7 +9,9 @@ import { AddFavouriteUseCase, FavouriteAlreadyExistsError } from "../../applicat
 import { RemoveFavouriteUseCase } from "../../application/use-cases/remove-favourite";
 import { corsHeaders } from "../../../http/cors";
 
-const dynamo = new DynamoDBClient({});
+const dynamo = new DynamoDBClient({
+  endpoint: process.env.AWS_ENDPOINT_URL_DYNAMODB,
+});
 const repository = new DynamoUserProfileRepository(
   dynamo,
   process.env.USER_STATE_TABLE!

--- a/src/backend/src/users/interfaces/http/profile-routes.ts
+++ b/src/backend/src/users/interfaces/http/profile-routes.ts
@@ -7,7 +7,9 @@ import { Email } from "../../../shared/domain/value-objects/email";
 import { UserProfile } from "../../domain/entities/user-profile";
 import { corsHeaders } from "../../../http/cors";
 
-const dynamo = new DynamoDBClient({});
+const dynamo = new DynamoDBClient({
+  endpoint: process.env.AWS_ENDPOINT_URL_DYNAMODB,
+});
 const repository = new DynamoUserProfileRepository(
   dynamo,
   process.env.USER_STATE_TABLE!

--- a/src/backend/test/integration/favourite-routes.integration.test.ts
+++ b/src/backend/test/integration/favourite-routes.integration.test.ts
@@ -25,7 +25,9 @@ beforeAll(async () => {
   process.env.AWS_ENDPOINT_URL_DYNAMODB = `http://localhost:${PORT}`;
   process.env.USER_STATE_TABLE = TABLE_NAME;
 
-  client = new DynamoDBClient({});
+  client = new DynamoDBClient({
+    endpoint: process.env.AWS_ENDPOINT_URL_DYNAMODB,
+  });
   await client.send(
     new CreateTableCommand({
       TableName: TABLE_NAME,


### PR DESCRIPTION
## Summary
- allow DynamoDB endpoint override via AWS_ENDPOINT_URL_DYNAMODB across services
- align favourite routes integration test with configurable endpoint

## Testing
- `npm run test:unit` *(fails: Cannot find module 'dynamodb-local')*


------
https://chatgpt.com/codex/tasks/task_e_68bcc3342ce4832f8db19537ca7b58ed