### PR TITLE
Await DynamoDB local launch in integration test

### DIFF
--- a/src/backend/test/integration/favourite-routes.integration.test.ts
+++ b/src/backend/test/integration/favourite-routes.integration.test.ts
@@ -15,9 +15,7 @@ const PORT = 8000;
 let client: DynamoDBClient;
 
 beforeAll(async () => {
-  dynamodbLocal.launch(PORT, null, ["-inMemory", "-sharedDb"]);
-  // wait a bit for dynamodb to start
-  await new Promise((res) => setTimeout(res, 1000));
+  await dynamodbLocal.launch(PORT, null, ["-inMemory", "-sharedDb"]);
 
   process.env.AWS_REGION = "us-east-1";
   process.env.AWS_ACCESS_KEY_ID = "x";


### PR DESCRIPTION
## Summary
- await DynamoDB local launch in favourite routes integration test
- remove manual timeout delay once launch is awaited

## Testing
- `npm run test:unit` *(fails: Cannot find module 'dynamodb-local')*

------
https://chatgpt.com/codex/tasks/task_e_68bcc3391120832fba6dd66f981e3820