### PR TITLE
Add integration tests for favourite routes

### DIFF
--- a/src/backend/src/users/interfaces/http/favourite-routes.test.ts
+++ b/src/backend/src/users/interfaces/http/favourite-routes.test.ts
@@ -42,7 +42,7 @@ describe("favourite routes handler", () => {
       ...baseCtx,
       httpMethod: "GET",
     });
-    expect(mockGet).toHaveBeenCalledWith("test@example.com");
+    expect(mockGet.mock.calls[0][0].Value).toBe("test@example.com");
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ favourites: ["1", "2"] });
   });
@@ -54,8 +54,9 @@ describe("favourite routes handler", () => {
       httpMethod: "POST",
       body: JSON.stringify({ routeId: "1" }),
     });
-    expect(mockGet).toHaveBeenCalledWith("test@example.com");
-    expect(mockPut).toHaveBeenCalledWith("test@example.com", "1");
+    expect(mockGet.mock.calls[0][0].Value).toBe("test@example.com");
+    expect(mockPut.mock.calls[0][0].Value).toBe("test@example.com");
+    expect(mockPut.mock.calls[0][1]).toBe("1");
     expect(mockPublishSaved).toHaveBeenCalledWith("test@example.com", "1");
     expect(res.statusCode).toBe(200);
   });
@@ -67,7 +68,7 @@ describe("favourite routes handler", () => {
       httpMethod: "POST",
       body: JSON.stringify({ routeId: "1" }),
     });
-    expect(mockGet).toHaveBeenCalledWith("test@example.com");
+    expect(mockGet.mock.calls[0][0].Value).toBe("test@example.com");
     expect(mockPut).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(409);
   });
@@ -98,7 +99,8 @@ describe("favourite routes handler", () => {
       httpMethod: "DELETE",
       pathParameters: { routeId: "2" },
     });
-    expect(mockDelete).toHaveBeenCalledWith("test@example.com", "2");
+    expect(mockDelete.mock.calls[0][0].Value).toBe("test@example.com");
+    expect(mockDelete.mock.calls[0][1]).toBe("2");
     expect(mockPublishDeleted).toHaveBeenCalledWith("test@example.com", "2");
     expect(res.statusCode).toBe(200);
   });

--- a/src/backend/test/integration/favourite-routes.integration.test.ts
+++ b/src/backend/test/integration/favourite-routes.integration.test.ts
@@ -1,0 +1,101 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+
+process.env.AWS_REGION = "us-east-1";
+process.env.USER_STATE_TABLE = "UserState";
+
+// in-memory store to mimic DynamoDB Local
+const store = new Map<string, any>();
+
+// mock DynamoDBClient send method to interact with in-memory store
+const sendMock = jest
+  .spyOn(DynamoDBClient.prototype, "send")
+  .mockImplementation(async (command: any) => {
+    const name = command.constructor.name;
+    if (name === "PutItemCommand") {
+      const item = command.input.Item as any;
+      const pk = item.PK.S as string;
+      const sk = item.SK.S as string;
+      store.set(`${pk}|${sk}`, item);
+      return {} as any;
+    }
+    if (name === "DeleteItemCommand") {
+      const pk = command.input.Key!.PK.S as string;
+      const sk = command.input.Key!.SK.S as string;
+      store.delete(`${pk}|${sk}`);
+      return {} as any;
+    }
+    if (name === "QueryCommand") {
+      const pk = command.input.ExpressionAttributeValues![":pk"].S as string;
+      const fav = command.input.ExpressionAttributeValues![":fav"].S as string;
+      const items = Array.from(store.values()).filter(
+        (i) => i.PK.S === pk && i.SK.S.startsWith(fav)
+      );
+      return { Items: items } as any;
+    }
+    return {} as any;
+  });
+
+import { handler } from "../../src/users/interfaces/http/favourite-routes";
+
+describe("favourite routes integration", () => {
+  const email = "test@example.com";
+  const baseEvent: any = {
+    requestContext: { authorizer: { claims: { email } } },
+  };
+  const key = (routeId: string) => `USER#${email}|FAV#${routeId}`;
+
+  beforeEach(() => {
+    store.clear();
+  });
+
+  afterAll(() => {
+    sendMock.mockRestore();
+  });
+
+  it("returns favourites on GET", async () => {
+    store.set(key("1"), { PK: { S: `USER#${email}` }, SK: { S: "FAV#1" } });
+    store.set(key("2"), { PK: { S: `USER#${email}` }, SK: { S: "FAV#2" } });
+
+    const res = await handler({ ...baseEvent, httpMethod: "GET" });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ favourites: ["1", "2"] });
+  });
+
+  it("adds favourite on POST", async () => {
+    const res = await handler({
+      ...baseEvent,
+      httpMethod: "POST",
+      body: JSON.stringify({ routeId: "1" }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(store.get(key("1"))).toBeDefined();
+  });
+
+  it("returns 409 when favourite already exists", async () => {
+    store.set(key("1"), { PK: { S: `USER#${email}` }, SK: { S: "FAV#1" } });
+
+    const res = await handler({
+      ...baseEvent,
+      httpMethod: "POST",
+      body: JSON.stringify({ routeId: "1" }),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(store.get(key("1"))).toBeDefined();
+  });
+
+  it("deletes favourite on DELETE", async () => {
+    store.set(key("2"), { PK: { S: `USER#${email}` }, SK: { S: "FAV#2" } });
+
+    const res = await handler({
+      ...baseEvent,
+      httpMethod: "DELETE",
+      pathParameters: { routeId: "2" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(store.get(key("2"))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add integration tests covering favourite routes GET/POST/DELETE flows
- ensure favourite routes handler uses Email value object and publishes events with email string

## Testing
- `cd src/backend && npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68bcd20199e0832fb15f4079948832a4