### PR TITLE
feat: standardize backend error responses

### DIFF
--- a/src/backend/src/http/error-response.ts
+++ b/src/backend/src/http/error-response.ts
@@ -1,0 +1,18 @@
+import { APIGatewayProxyResult } from "aws-lambda";
+import { corsHeaders } from "./cors";
+
+export function errorResponse(
+  code: number,
+  message: string,
+  details?: unknown
+): APIGatewayProxyResult {
+  const body: Record<string, unknown> = { code, message };
+  if (details !== undefined) {
+    body.details = details;
+  }
+  return {
+    statusCode: code,
+    headers: corsHeaders,
+    body: JSON.stringify(body),
+  };
+}

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -12,6 +12,7 @@ import { GetRouteDetailsUseCase } from "../../application/use-cases/get-route-de
 import { StartRouteUseCase } from "../../application/use-cases/start-route";
 import { FinishRouteUseCase } from "../../application/use-cases/finish-route";
 import { corsHeaders } from "../../../http/cors";
+import { errorResponse } from "../../../http/error-response";
 import { getGoogleKey } from "../shared/utils";
 import { GoogleMapsProvider } from "../../infrastructure/google-maps/google-maps-provider";
 import {
@@ -102,11 +103,7 @@ export const handler = async (
   const { httpMethod, resource, pathParameters } = event;
   const email = (event.requestContext as any).authorizer?.claims?.email;
   if (!email) {
-    return {
-      statusCode: 401,
-      headers: corsHeaders,
-      body: JSON.stringify({ error: "Unauthorized" }),
-    };
+    return errorResponse(401, "Unauthorized");
   }
   // GET /routes
   if (httpMethod === "GET" && resource === "/routes") {
@@ -127,11 +124,7 @@ export const handler = async (
       };
     } catch (err) {
       console.error("Error listing routes:", err);
-      return {
-        statusCode: 500,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "Could not list routes" }),
-      };
+      return errorResponse(500, "Could not list routes");
     }
   }
 
@@ -139,20 +132,12 @@ export const handler = async (
   if (httpMethod === "GET" && resource === "/routes/{routeId}") {
     const routeId = pathParameters?.routeId;
     if (!routeId) {
-      return {
-        statusCode: 400,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "routeId parameter required" }),
-      };
+      return errorResponse(400, "routeId parameter required");
     }
 
     const route = await routeRepository.findById(UUID.fromString(routeId));
     if (!route) {
-      return {
-        statusCode: 404,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "Not Found" }),
-      };
+      return errorResponse(404, "Not Found");
     }
     if (!route.description && route.path) {
       try {
@@ -186,11 +171,7 @@ export const handler = async (
   if (httpMethod === "GET" && resource === "/jobs/{jobId}/routes") {
     const jobId = pathParameters?.jobId;
     if (!jobId) {
-      return {
-        statusCode: 400,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "jobId parameter required" }),
-      };
+      return errorResponse(400, "jobId parameter required");
     }
     try {
       const list = await routeRepository.findByJobId(UUID.fromString(jobId));
@@ -209,11 +190,7 @@ export const handler = async (
       };
     } catch (err) {
       console.error("Error listing job routes:", err);
-      return {
-        statusCode: 500,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "Could not list routes" }),
-      };
+      return errorResponse(500, "Could not list routes");
     }
   }
 
@@ -223,21 +200,13 @@ export const handler = async (
       try {
         payload = JSON.parse(event.body);
       } catch {
-        return {
-          statusCode: 400,
-          headers: corsHeaders,
-          body: JSON.stringify({ error: "Invalid JSON body" }),
-        };
+        return errorResponse(400, "Invalid JSON body");
       }
     }
 
     const routeId = payload.routeId;
     if (!routeId) {
-      return {
-        statusCode: 400,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "routeId required" }),
-      };
+      return errorResponse(400, "routeId required");
     }
 
     const ts = Date.now();
@@ -248,11 +217,7 @@ export const handler = async (
       timestamp: ts,
     });
     if (!started) {
-      return {
-        statusCode: 404,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "Not Found" }),
-      };
+      return errorResponse(404, "Not Found");
     }
     return {
       statusCode: 200,
@@ -264,11 +229,7 @@ export const handler = async (
   if (resource === "/routes/{routeId}/finish" && httpMethod === "POST") {
     const routeId = pathParameters?.routeId;
     if (!routeId) {
-      return {
-        statusCode: 400,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "routeId parameter required" }),
-      };
+      return errorResponse(400, "routeId parameter required");
     }
 
     const finishTs = Date.now();
@@ -288,11 +249,7 @@ export const handler = async (
       actualDuration,
     });
     if (!route) {
-      return {
-        statusCode: 404,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "Not Found" }),
-      };
+      return errorResponse(404, "Not Found");
     }
 
     return {
@@ -309,9 +266,5 @@ export const handler = async (
     };
   }
 
-  return {
-    statusCode: 501,
-    headers: corsHeaders,
-    body: JSON.stringify({ error: "Not Implemented" }),
-  };
+  return errorResponse(501, "Not Implemented");
 };

--- a/src/backend/src/routes/interfaces/http/request-routes.test.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.test.ts
@@ -52,7 +52,10 @@ describe("request routes handler", () => {
   it("returns 400 when body parsing fails", async () => {
     const res = await handler({ body: '{"invalid"' } as any);
     expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toBeDefined();
+    expect(JSON.parse(res.body)).toEqual({
+      code: 400,
+      message: "Invalid JSON body",
+    });
     expect(mockSend).not.toHaveBeenCalled();
   });
 
@@ -60,8 +63,16 @@ describe("request routes handler", () => {
     mockSend.mockResolvedValueOnce({});
     const res1 = await handler({ body: JSON.stringify({ destination: "B" }) } as any);
     expect(res1.statusCode).toBe(400);
+    expect(JSON.parse(res1.body)).toEqual({
+      code: 400,
+      message: "Must provide origin and (destination OR distanceKm)",
+    });
     const res2 = await handler({ body: JSON.stringify({ origin: "A" }) } as any);
     expect(res2.statusCode).toBe(400);
+    expect(JSON.parse(res2.body)).toEqual({
+      code: 400,
+      message: "Must provide origin and (destination OR distanceKm)",
+    });
   });
 
   it("forwards maxDeltaKm when provided", async () => {

--- a/src/backend/src/routes/interfaces/http/request-routes.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.ts
@@ -2,6 +2,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 import { UUID } from "../../../shared/domain/value-objects/uuid";
 import { corsHeaders } from "../../../http/cors";
+import { errorResponse } from "../../../http/error-response";
 
 const sqs = new SQSClient({});
 
@@ -13,11 +14,7 @@ export const handler = async (
     try {
       data = JSON.parse(event.body);
     } catch (err) {
-      return {
-        statusCode: 400,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "Invalid JSON body" }),
-      };
+      return errorResponse(400, "Invalid JSON body");
     }
   }
 
@@ -25,13 +22,10 @@ export const handler = async (
     typeof data.origin !== "string" ||
     (!data.destination && data.distanceKm == null)
   ) {
-    return {
-      statusCode: 400,
-      headers: corsHeaders,
-      body: JSON.stringify({
-        error: "Must provide origin and (destination OR distanceKm)",
-      }),
-    };
+    return errorResponse(
+      400,
+      "Must provide origin and (destination OR distanceKm)"
+    );
   }
 
   if (!data.jobId) {

--- a/src/backend/src/users/interfaces/http/favourite-routes.ts
+++ b/src/backend/src/users/interfaces/http/favourite-routes.ts
@@ -8,6 +8,7 @@ import {
 import { AddFavouriteUseCase, FavouriteAlreadyExistsError } from "../../application/use-cases/add-favourite";
 import { RemoveFavouriteUseCase } from "../../application/use-cases/remove-favourite";
 import { corsHeaders } from "../../../http/cors";
+import { errorResponse } from "../../../http/error-response";
 import { Email } from "../../../shared/domain/value-objects/email";
 
 const dynamo = new DynamoDBClient({
@@ -25,7 +26,7 @@ export const handler = async (
 ): Promise<APIGatewayProxyResult> => {
   const emailStr = (event.requestContext as any).authorizer?.claims?.email;
   if (!emailStr) {
-    return { statusCode: 401, headers: corsHeaders, body: JSON.stringify({ error: "Unauthorized" }) };
+    return errorResponse(401, "Unauthorized");
   }
   const email = Email.fromString(emailStr);
 
@@ -42,11 +43,7 @@ export const handler = async (
       };
     } catch (err) {
       console.error("❌ Error reading favourites:", err);
-      return {
-        statusCode: 500,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "Could not fetch favourites" }),
-      };
+      return errorResponse(500, "Could not fetch favourites");
     }
   }
 
@@ -55,31 +52,19 @@ export const handler = async (
     try {
       payload = event.body ? JSON.parse(event.body) : {};
     } catch {
-      return {
-        statusCode: 400,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "Invalid JSON body" }),
-      };
+      return errorResponse(400, "Invalid JSON body");
     }
 
     const routeId = payload.routeId;
     if (!routeId) {
-      return {
-        statusCode: 400,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "routeId required" }),
-      };
+      return errorResponse(400, "routeId required");
     }
 
     try {
       await addFavourite.execute(email, routeId);
     } catch (err) {
       if (err instanceof FavouriteAlreadyExistsError) {
-        return {
-          statusCode: 409,
-          headers: corsHeaders,
-          body: JSON.stringify({ error: "Route already in favourites" }),
-        };
+        return errorResponse(409, "Route already in favourites");
       }
       throw err;
     }
@@ -90,20 +75,12 @@ export const handler = async (
   if (httpMethod === "DELETE") {
     const routeId = event.pathParameters?.routeId;
     if (!routeId) {
-      return {
-        statusCode: 400,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "routeId parameter required" }),
-      };
+      return errorResponse(400, "routeId parameter required");
     }
     await removeFavourite.execute(email, routeId);
     await publishFavouriteDeleted(email.Value, routeId);
     return { statusCode: 200, headers: corsHeaders, body: JSON.stringify({ deleted: true }) };
   }
 
-  return {
-    statusCode: 501,
-    headers: corsHeaders,
-    body: JSON.stringify({ error: "Not Implemented" }),
-  };
+  return errorResponse(501, "Not Implemented");
 };

--- a/src/backend/src/users/interfaces/http/profile-routes.ts
+++ b/src/backend/src/users/interfaces/http/profile-routes.ts
@@ -6,6 +6,7 @@ import { UpdateUserProfileUseCase } from "../../application/use-cases/update-use
 import { Email } from "../../../shared/domain/value-objects/email";
 import { UserProfile } from "../../domain/entities/user-profile";
 import { corsHeaders } from "../../../http/cors";
+import { errorResponse } from "../../../http/error-response";
 
 const dynamo = new DynamoDBClient({
   endpoint: process.env.AWS_ENDPOINT_URL_DYNAMODB,
@@ -22,7 +23,7 @@ export const handler = async (
 ): Promise<APIGatewayProxyResult> => {
   const email = (event.requestContext as any).authorizer?.claims?.email;
   if (!email) {
-    return { statusCode: 401, headers: corsHeaders, body: JSON.stringify({ error: "Unauthorized" }) };
+    return errorResponse(401, "Unauthorized");
   }
   const { httpMethod } = event;
 
@@ -37,7 +38,7 @@ export const handler = async (
       try {
         payload = JSON.parse(event.body);
       } catch {
-        return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: "Invalid JSON body" }) };
+        return errorResponse(400, "Invalid JSON body");
       }
     }
     const profile = UserProfile.fromPrimitives({
@@ -52,5 +53,5 @@ export const handler = async (
     return { statusCode: 200, headers: corsHeaders, body: JSON.stringify({ updated: true }) };
   }
 
-  return { statusCode: 501, headers: corsHeaders, body: JSON.stringify({ error: "Not Implemented" }) };
+  return errorResponse(501, "Not Implemented");
 };

--- a/src/backend/test/integration/favourite-routes.integration.test.ts
+++ b/src/backend/test/integration/favourite-routes.integration.test.ts
@@ -83,6 +83,10 @@ describe("favourite routes integration", () => {
     });
 
     expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      code: 409,
+      message: "Route already in favourites",
+    });
     expect(store.get(key("1"))).toBeDefined();
   });
 
@@ -97,5 +101,12 @@ describe("favourite routes integration", () => {
 
     expect(res.statusCode).toBe(200);
     expect(store.get(key("2"))).toBeUndefined();
+  });
+
+  it("returns 401 when unauthorized", async () => {
+    const res = await handler({ httpMethod: "GET", requestContext: {} as any });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ code: 401, message: "Unauthorized" });
   });
 });

--- a/src/backend/test/integration/profile-routes.integration.test.ts
+++ b/src/backend/test/integration/profile-routes.integration.test.ts
@@ -79,5 +79,12 @@ describe("profile routes integration", () => {
     expect(item.firstName.S).toBe("Jane");
     expect(item.lastName.S).toBe("Doe");
   });
+
+  it("returns 401 when unauthorized", async () => {
+    const res = await handler({ httpMethod: "GET", requestContext: {} as any });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ code: 401, message: "Unauthorized" });
+  });
 });
 


### PR DESCRIPTION
## Summary
- add reusable `errorResponse` helper for consistent `{code, message}` payloads
- replace manual error payloads in route and user handlers to use helper
- update tests to expect new error structure

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68bd458f5e6c832fa843ae273e58b6c8