### PR TITLE
Add request trace middleware and error handling

### DIFF
--- a/src/backend/src/docs/interfaces/http/swagger.ts
+++ b/src/backend/src/docs/interfaces/http/swagger.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { openApiSpec } from "../../openapi";
-import { corsHeaders } from "../../../http/cors";
+import { corsHeaders, withTraceId } from "../../../http";
 
 const html = `<!DOCTYPE html>
 <html>
@@ -26,9 +26,8 @@ const html = `<!DOCTYPE html>
   </body>
 </html>`;
 
-export const handler = async (
-  event: APIGatewayProxyEvent
-): Promise<APIGatewayProxyResult> => {
+export const handler = withTraceId(
+  async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   if (event.path.endsWith("/swagger.json")) {
     return {
       statusCode: 200,
@@ -42,4 +41,4 @@ export const handler = async (
     headers: { ...corsHeaders, "Content-Type": "text/html" },
     body: html,
   };
-};
+});

--- a/src/backend/src/http/error-response.ts
+++ b/src/backend/src/http/error-response.ts
@@ -1,0 +1,17 @@
+import { APIGatewayProxyResult } from "aws-lambda";
+import { corsHeaders } from "./cors";
+import { getTraceId } from "./trace-context";
+
+export function errorResponse(
+  statusCode: number,
+  message: string,
+  traceId: string | undefined = getTraceId()
+): APIGatewayProxyResult {
+  return {
+    statusCode,
+    headers: corsHeaders,
+    body: JSON.stringify(
+      traceId ? { error: message, traceId } : { error: message }
+    ),
+  };
+}

--- a/src/backend/src/http/index.ts
+++ b/src/backend/src/http/index.ts
@@ -1,0 +1,3 @@
+export { corsHeaders } from "./cors";
+export { withTraceId } from "./middleware";
+export { errorResponse } from "./error-response";

--- a/src/backend/src/http/middleware.ts
+++ b/src/backend/src/http/middleware.ts
@@ -1,0 +1,39 @@
+import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda";
+import { UUID } from "../shared/domain/value-objects/uuid";
+import { setTraceId, clearTraceId } from "./trace-context";
+import { errorResponse } from "./error-response";
+
+export function withTraceId(
+  handler: APIGatewayProxyHandler
+): APIGatewayProxyHandler {
+  return async (event, context): Promise<APIGatewayProxyResult> => {
+    const traceId = UUID.generate().Value;
+    setTraceId(traceId);
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = (...args: any[]) => originalLog(`[${traceId}]`, ...args);
+    console.error = (...args: any[]) => originalError(`[${traceId}]`, ...args);
+    try {
+      const result = await handler(event, context);
+      if (result.statusCode >= 400) {
+        try {
+          const body = JSON.parse(result.body);
+          if (body && typeof body === "object" && body.error && !body.traceId) {
+            body.traceId = traceId;
+            result.body = JSON.stringify(body);
+          }
+        } catch {
+          // ignore parse errors
+        }
+      }
+      return result;
+    } catch (err) {
+      console.error("Unhandled error:", err);
+      return errorResponse(500, "Internal Server Error", traceId);
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+      clearTraceId();
+    }
+  };
+}

--- a/src/backend/src/http/trace-context.ts
+++ b/src/backend/src/http/trace-context.ts
@@ -1,0 +1,13 @@
+let currentTraceId: string | undefined;
+
+export function setTraceId(id: string) {
+  currentTraceId = id;
+}
+
+export function getTraceId(): string | undefined {
+  return currentTraceId;
+}
+
+export function clearTraceId() {
+  currentTraceId = undefined;
+}

--- a/src/backend/src/routes/interfaces/http/request-routes.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.ts
@@ -1,23 +1,18 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 import { UUID } from "../../../shared/domain/value-objects/uuid";
-import { corsHeaders } from "../../../http/cors";
+import { corsHeaders, withTraceId, errorResponse } from "../../../http";
 
 const sqs = new SQSClient({});
 
-export const handler = async (
-  event: APIGatewayProxyEvent
-): Promise<APIGatewayProxyResult> => {
+export const handler = withTraceId(
+  async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   let data: any = {};
   if (event.body) {
     try {
       data = JSON.parse(event.body);
     } catch (err) {
-      return {
-        statusCode: 400,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "Invalid JSON body" }),
-      };
+      return errorResponse(400, "Invalid JSON body");
     }
   }
 
@@ -25,13 +20,10 @@ export const handler = async (
     typeof data.origin !== "string" ||
     (!data.destination && data.distanceKm == null)
   ) {
-    return {
-      statusCode: 400,
-      headers: corsHeaders,
-      body: JSON.stringify({
-        error: "Must provide origin and (destination OR distanceKm)",
-      }),
-    };
+    return errorResponse(
+      400,
+      "Must provide origin and (destination OR distanceKm)"
+    );
   }
 
   if (!data.jobId) {
@@ -72,4 +64,4 @@ export const handler = async (
     headers: corsHeaders,
     body: JSON.stringify({ enqueued: true, jobId: data.jobId }),
   };
-};
+});


### PR DESCRIPTION
## Summary
- generate per-request UUID traceId in base HTTP middleware
- prefix logs with traceId and include it in error responses
- wrap HTTP handlers with middleware and use shared errorResponse helper

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68bd4597e574832fb45d97ef671becb3