### PR TITLE
feat: add cursor pagination to route listing

### DIFF
--- a/src/backend/src/routes/application/use-cases/describe-route.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/describe-route.usecase.test.ts
@@ -19,7 +19,7 @@ describe('DescribeRouteUseCase', () => {
     const repo: RouteRepository = {
       findById: jest.fn().mockResolvedValue(route),
       save: jest.fn(),
-      findAll: jest.fn(),
+      findAll: jest.fn().mockResolvedValue({ items: [] }),
       findByJobId: jest.fn(),
       remove: jest.fn(),
     } as any;

--- a/src/backend/src/routes/application/use-cases/get-route-details.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/get-route-details.usecase.test.ts
@@ -8,7 +8,8 @@ describe('GetRouteDetailsUseCase', () => {
     const route = Route.request({ routeId: UUID.generate() });
     const repo: RouteRepository = {
       findById: jest.fn().mockResolvedValue(route),
-      findAll: jest.fn(),
+      findAll: jest.fn().mockResolvedValue({ items: [] }),
+      findByJobId: jest.fn(),
       save: jest.fn(),
       remove: jest.fn(),
     } as any;

--- a/src/backend/src/routes/application/use-cases/list-routes.ts
+++ b/src/backend/src/routes/application/use-cases/list-routes.ts
@@ -1,10 +1,12 @@
-import { RouteRepository } from '../../domain/repositories/route-repository';
-import { Route } from '../../domain/entities/route';
+import { RouteRepository } from "../../domain/repositories/route-repository";
+import { Route } from "../../domain/entities/route";
 
 export class ListRoutesUseCase {
   constructor(private repository: RouteRepository) {}
 
-  async execute(): Promise<Route[]> {
-    return this.repository.findAll();
+  async execute(
+    params?: { cursor?: string; limit?: number }
+  ): Promise<{ items: Route[]; nextCursor?: string }> {
+    return this.repository.findAll(params);
   }
 }

--- a/src/backend/src/routes/application/use-cases/list-routes.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/list-routes.usecase.test.ts
@@ -1,20 +1,23 @@
-import { ListRoutesUseCase } from './list-routes';
-import { RouteRepository } from '../../domain/repositories/route-repository';
-import { Route } from '../../domain/entities/route';
-import { UUID } from '../../../shared/domain/value-objects/uuid';
+import { ListRoutesUseCase } from "./list-routes";
+import { RouteRepository } from "../../domain/repositories/route-repository";
+import { Route } from "../../domain/entities/route";
+import { UUID } from "../../../shared/domain/value-objects/uuid";
 
 describe('ListRoutesUseCase', () => {
-  it('returns all routes from repository', async () => {
+  it("returns items and nextCursor from repository", async () => {
     const routes = [Route.request({ routeId: UUID.generate() })];
     const repo: RouteRepository = {
-      findAll: jest.fn().mockResolvedValue(routes),
+      findAll: jest
+        .fn()
+        .mockResolvedValue({ items: routes, nextCursor: "next" }),
       findById: jest.fn(),
       save: jest.fn(),
       remove: jest.fn(),
+      findByJobId: jest.fn(),
     } as any;
     const useCase = new ListRoutesUseCase(repo);
-    const result = await useCase.execute();
-    expect(repo.findAll).toHaveBeenCalled();
-    expect(result).toBe(routes);
+    const result = await useCase.execute({ cursor: "cur", limit: 5 });
+    expect(repo.findAll).toHaveBeenCalledWith({ cursor: "cur", limit: 5 });
+    expect(result).toEqual({ items: routes, nextCursor: "next" });
   });
 });

--- a/src/backend/src/routes/domain/repositories/route-repository.ts
+++ b/src/backend/src/routes/domain/repositories/route-repository.ts
@@ -4,7 +4,9 @@ import { UUID } from "../../../shared/domain/value-objects/uuid";
 export interface RouteRepository {
   save(route: Route): Promise<void>;
   findById(id: UUID): Promise<Route | null>;
-  findAll(): Promise<Route[]>;
+  findAll(
+    params?: { cursor?: string; limit?: number }
+  ): Promise<{ items: Route[]; nextCursor?: string }>;
   findByJobId(jobId: UUID): Promise<Route[]>;
   remove(id: UUID): Promise<void>;
 }

--- a/src/backend/src/routes/domain/services/route-generator.test.ts
+++ b/src/backend/src/routes/domain/services/route-generator.test.ts
@@ -20,7 +20,7 @@ describe("RouteGenerator", () => {
     const repo: RouteRepository = {
       save: jest.fn(),
       findById: jest.fn(),
-      findAll: jest.fn(),
+      findAll: jest.fn().mockResolvedValue({ items: [] }),
       findByJobId: jest.fn(),
       remove: jest.fn(),
     } as any;
@@ -49,7 +49,7 @@ describe("RouteGenerator", () => {
     const repo: RouteRepository = {
       save,
       findById: jest.fn(),
-      findAll: jest.fn(),
+      findAll: jest.fn().mockResolvedValue({ items: [] }),
       findByJobId: jest.fn(),
       remove: jest.fn(),
     } as any;

--- a/src/backend/src/routes/infrastructure/in-memory/in-memory-route-repository.test.ts
+++ b/src/backend/src/routes/infrastructure/in-memory/in-memory-route-repository.test.ts
@@ -65,10 +65,27 @@ describe("InMemoryRouteRepository", () => {
     await repo.save(routeB);
 
     const all = await repo.findAll();
-    expect(all).toHaveLength(2);
-    expect(all.map((r) => r.routeId.Value)).toEqual(
+    expect(all.items).toHaveLength(2);
+    expect(all.items.map((r) => r.routeId.Value)).toEqual(
       expect.arrayContaining([routeA.routeId.Value, routeB.routeId.Value])
     );
+  });
+
+  it("supports pagination", async () => {
+    const r1 = Route.request({ routeId: UUID.generate() });
+    const r2 = Route.request({ routeId: UUID.generate() });
+    const r3 = Route.request({ routeId: UUID.generate() });
+    await repo.save(r1);
+    await repo.save(r2);
+    await repo.save(r3);
+
+    const page1 = await repo.findAll({ limit: 2 });
+    expect(page1.items).toHaveLength(2);
+    expect(page1.nextCursor).toBe(page1.items[1].routeId.Value);
+
+    const page2 = await repo.findAll({ cursor: page1.nextCursor });
+    expect(page2.items).toHaveLength(1);
+    expect(page2.items[0].routeId.Value).toBe(r3.routeId.Value);
   });
 
   it("findByJobId filters routes by jobId", async () => {

--- a/src/backend/src/routes/infrastructure/in-memory/in-memory-route-repository.ts
+++ b/src/backend/src/routes/infrastructure/in-memory/in-memory-route-repository.ts
@@ -13,8 +13,23 @@ export class InMemoryRouteRepository implements RouteRepository {
     return this.routes.get(id.Value) ?? null;
   }
 
-  async findAll(): Promise<Route[]> {
-    return Array.from(this.routes.values());
+  async findAll(
+    params?: { cursor?: string; limit?: number }
+  ): Promise<{ items: Route[]; nextCursor?: string }> {
+    const all = Array.from(this.routes.values());
+    let startIndex = 0;
+    if (params?.cursor) {
+      const idx = all.findIndex((r) => r.routeId.Value === params.cursor);
+      startIndex = idx >= 0 ? idx + 1 : 0;
+    }
+    const limit = params?.limit ?? all.length;
+    const items = all.slice(startIndex, startIndex + limit);
+    const nextIndex = startIndex + limit;
+    const nextCursor =
+      nextIndex < all.length && items.length > 0
+        ? items[items.length - 1].routeId.Value
+        : undefined;
+    return nextCursor ? { items, nextCursor } : { items };
   }
 
   async findByJobId(jobId: UUID): Promise<Route[]> {

--- a/src/backend/src/routes/interfaces/http/page-router.test.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.test.ts
@@ -133,13 +133,12 @@ describe("page router list routes", () => {
   } as any;
 
   it("returns 200 and empty array when no routes exist", async () => {
-    mockFindAll.mockResolvedValueOnce([]);
+    mockFindAll.mockResolvedValueOnce({ items: [] });
     const res = await handler(baseEvent);
     expect(mockFindAll).toHaveBeenCalled();
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
-    expect(Array.isArray(body)).toBe(true);
-    expect(body).toHaveLength(0);
+    expect(body).toEqual({ items: [] });
   });
 
   it("returns 200 and list of routes when routes exist", async () => {
@@ -163,7 +162,7 @@ describe("page router list routes", () => {
       ])
     );
     route2.description = "b";
-    mockFindAll.mockResolvedValueOnce([route1, route2]);
+    mockFindAll.mockResolvedValueOnce({ items: [route1, route2] });
 
     const res = await handler(baseEvent);
 
@@ -171,22 +170,47 @@ describe("page router list routes", () => {
     expect(res.statusCode).toBe(200);
 
     const body = JSON.parse(res.body);
-    expect(body).toEqual([
-      {
-        routeId: route1.routeId.Value,
-        distanceKm: 1,
-        duration: 10,
-        path: route1.path!.Encoded,
-        description: "a",
-      },
-      {
-        routeId: route2.routeId.Value,
-        distanceKm: 2,
-        duration: 20,
-        path: route2.path!.Encoded,
-        description: "b",
-      },
-    ]);
+    expect(body).toEqual({
+      items: [
+        {
+          routeId: route1.routeId.Value,
+          distanceKm: 1,
+          duration: 10,
+          path: route1.path!.Encoded,
+          description: "a",
+        },
+        {
+          routeId: route2.routeId.Value,
+          distanceKm: 2,
+          duration: 20,
+          path: route2.path!.Encoded,
+          description: "b",
+        },
+      ],
+    });
+  });
+
+  it("passes cursor and limit and returns nextCursor", async () => {
+    const route = Route.request({ routeId: UUID.generate() });
+    mockFindAll.mockResolvedValueOnce({ items: [route], nextCursor: "n1" });
+    const res = await handler({
+      ...baseEvent,
+      queryStringParameters: { cursor: "c0", limit: "1" },
+    });
+    expect(mockFindAll).toHaveBeenCalledWith({ cursor: "c0", limit: 1 });
+    const body = JSON.parse(res.body);
+    expect(body).toEqual({
+      items: [
+        {
+          routeId: route.routeId.Value,
+          distanceKm: undefined,
+          duration: undefined,
+          path: undefined,
+          description: undefined,
+        },
+      ],
+      nextCursor: "n1",
+    });
   });
 });
 

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -111,19 +111,26 @@ export const handler = async (
   // GET /routes
   if (httpMethod === "GET" && resource === "/routes") {
     try {
-      const all = await listRoutes.execute();
+      const cursor = event.queryStringParameters?.cursor;
+      const limitParam = event.queryStringParameters?.limit;
+      const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+      const { items, nextCursor } = await listRoutes.execute({
+        cursor,
+        limit,
+      });
       return {
         statusCode: 200,
         headers: corsHeaders,
-        body: JSON.stringify(
-          all.map((r) => ({
+        body: JSON.stringify({
+          items: items.map((r) => ({
             routeId: r.routeId.Value,
             distanceKm: r.distanceKm?.Value,
             duration: r.duration?.Value,
             path: r.path?.Encoded,
             description: r.description,
-          }))
-        ),
+          })),
+          ...(nextCursor ? { nextCursor } : {}),
+        }),
       };
     } catch (err) {
       console.error("Error listing routes:", err);


### PR DESCRIPTION
## Summary
- support cursor/limit pagination in route repository and use case
- handle `cursor` and `limit` query params for GET /routes and return `{ items, nextCursor }`
- add unit/integration tests for route listing pagination

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68bd45bff658832fb40767092a815a99