### PR TITLE
feat: add request rate limiting

### DIFF
--- a/src/backend/src/http/rate-limit.ts
+++ b/src/backend/src/http/rate-limit.ts
@@ -1,0 +1,51 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+
+export interface RateLimitOptions {
+  limit?: number;
+  windowMs?: number;
+  keyGenerator?: (event: APIGatewayProxyEvent) => string;
+}
+
+type Handler = (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>;
+
+const attempts = new Map<string, { count: number; expiresAt: number }>();
+
+export const rateLimit = (
+  handler: Handler,
+  { limit = 100, windowMs = 60_000, keyGenerator }: RateLimitOptions = {}
+): Handler => {
+  return async (
+    event: APIGatewayProxyEvent
+  ): Promise<APIGatewayProxyResult> => {
+    const key = keyGenerator
+      ? keyGenerator(event)
+      : (event.requestContext as any)?.authorizer?.claims?.sub ||
+        (event.requestContext as any)?.identity?.sourceIp ||
+        "unknown";
+
+    const now = Date.now();
+    const record = attempts.get(key);
+    if (!record || now > record.expiresAt) {
+      attempts.set(key, { count: 1, expiresAt: now + windowMs });
+    } else {
+      record.count += 1;
+    }
+
+    const current = attempts.get(key)!;
+    console.log(`rate-limit:${key}:${current.count}`);
+    if (current.count > limit) {
+      const retryAfter = Math.ceil((current.expiresAt - now) / 1000);
+      return {
+        statusCode: 429,
+        headers: { "Retry-After": String(retryAfter) },
+        body: JSON.stringify({ error: "Too Many Requests" }),
+      };
+    }
+
+    return handler(event);
+  };
+};
+
+export const resetRateLimit = () => {
+  attempts.clear();
+};

--- a/src/backend/test/integration/rate-limit.integration.test.ts
+++ b/src/backend/test/integration/rate-limit.integration.test.ts
@@ -1,0 +1,45 @@
+import { rateLimit, resetRateLimit } from "../../src/http/rate-limit";
+
+const baseEvent: any = {
+  requestContext: { identity: { sourceIp: "1.1.1.1" } },
+};
+
+describe("rate limit middleware", () => {
+  beforeEach(() => {
+    resetRateLimit();
+  });
+
+  it("returns 429 with Retry-After when limit exceeded", async () => {
+    const handler = rateLimit(async () => ({ statusCode: 200, headers: {}, body: "" }), {
+      limit: 2,
+      windowMs: 60_000,
+    });
+    await handler(baseEvent);
+    await handler(baseEvent);
+    const res = await handler(baseEvent);
+    expect(res.statusCode).toBe(429);
+    expect(res.headers["Retry-After"]).toBeDefined();
+  });
+
+  it("logs attempts", async () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const handler = rateLimit(async () => ({ statusCode: 200, headers: {}, body: "" }), {
+      limit: 5,
+      windowMs: 60_000,
+    });
+    await handler(baseEvent);
+    expect(logSpy).toHaveBeenCalledWith("rate-limit:1.1.1.1:1");
+    logSpy.mockRestore();
+  });
+
+  it("handles high traffic by blocking excess requests", async () => {
+    const handler = rateLimit(async () => ({ statusCode: 200, headers: {}, body: "" }), {
+      limit: 10,
+      windowMs: 60_000,
+    });
+    const requests = Array.from({ length: 15 }, () => handler(baseEvent));
+    const responses = await Promise.all(requests);
+    const overLimit = responses.filter((r) => r.statusCode === 429).length;
+    expect(overLimit).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- add in-memory rate limiting middleware that tracks requests and responds with 429 + `Retry-After`
- cover middleware with integration tests including high traffic scenarios

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68bd45c572e4832f91fb7b2653b24c37