### PR TITLE
feat(api): version routes under v1

### DIFF
--- a/infrastructure/lib/stacks/compute-stack.ts
+++ b/infrastructure/lib/stacks/compute-stack.ts
@@ -58,7 +58,7 @@ export class ComputeStack extends cdk.Stack {
       { cognitoUserPools: [props.userPool] }
     );
 
-    // 1) RequestRoutes → POST /routes
+    // 1) RequestRoutes → POST /v1/routes
     const requestRoutes = new HttpLambda(this, "RequestRoutes", {
       entry: path.join(
         __dirname,
@@ -67,7 +67,7 @@ export class ComputeStack extends cdk.Stack {
       handler: "request-routes.handler",
       environment: { QUEUE_URL: props.routeJobsQueue.queueUrl },
       api,
-      routes: [{ path: "routes", methods: ["POST"], authorizer }],
+      routes: [{ path: "v1/routes", methods: ["POST"], authorizer }],
     });
     props.routeJobsQueue.grantSendMessages(requestRoutes.fn);
 
@@ -106,7 +106,7 @@ export class ComputeStack extends cdk.Stack {
     );
     props.metricsQueue.grantSendMessages(workerRoutes.fn);
 
-    // 3) FavouriteRoutes → GET/POST /favourites & DELETE /favourites/{routeId}
+    // 3) FavouriteRoutes → GET/POST /v1/favourites & DELETE /v1/favourites/{routeId}
     const favoriteRoutes = new HttpLambda(this, "FavoriteRoutes", {
       entry: path.join(
         __dirname,
@@ -123,8 +123,8 @@ export class ComputeStack extends cdk.Stack {
       },
       api,
       routes: [
-        { path: "favourites", methods: ["GET", "POST"], authorizer },
-        { path: "favourites/{routeId}", methods: ["DELETE"], authorizer },
+        { path: "v1/favourites", methods: ["GET", "POST"], authorizer },
+        { path: "v1/favourites/{routeId}", methods: ["DELETE"], authorizer },
       ],
     });
     favoriteRoutes.fn.addToRolePolicy(
@@ -140,7 +140,7 @@ export class ComputeStack extends cdk.Stack {
       })
     );
 
-    // 4) ProfileRoutes → GET/PUT /profile
+    // 4) ProfileRoutes → GET/PUT /v1/profile
     const profileRoutes = new HttpLambda(this, "ProfileRoutes", {
       entry: path.join(
         __dirname,
@@ -156,7 +156,7 @@ export class ComputeStack extends cdk.Stack {
         ...(props.appSyncRegion ? { APPSYNC_REGION: props.appSyncRegion } : {}),
       },
       api,
-      routes: [{ path: "profile", methods: ["GET", "PUT"], authorizer }],
+      routes: [{ path: "v1/profile", methods: ["GET", "PUT"], authorizer }],
     });
     profileRoutes.fn.addToRolePolicy(
       new iam.PolicyStatement({
@@ -187,11 +187,11 @@ export class ComputeStack extends cdk.Stack {
       },
       api,
       routes: [
-        { path: "routes", methods: ["GET"], authorizer },
-        { path: "routes/{routeId}", methods: ["GET"], authorizer },
-        { path: "jobs/{jobId}/routes", methods: ["GET"], authorizer },
-        { path: "telemetry/started", methods: ["POST"], authorizer },
-        { path: "routes/{routeId}/finish", methods: ["POST"], authorizer },
+        { path: "v1/routes", methods: ["GET"], authorizer },
+        { path: "v1/routes/{routeId}", methods: ["GET"], authorizer },
+        { path: "v1/jobs/{jobId}/routes", methods: ["GET"], authorizer },
+        { path: "v1/telemetry/started", methods: ["POST"], authorizer },
+        { path: "v1/routes/{routeId}/finish", methods: ["POST"], authorizer },
       ],
     });
     googleSecret.grantRead(pageRouter.fn);

--- a/src/backend/src/docs/openapi.ts
+++ b/src/backend/src/docs/openapi.ts
@@ -17,7 +17,7 @@ export const openApiSpec = {
 
   security: [{ cognitoAuth: [] }],
   paths: {
-    "/routes": {
+    "/v1/routes": {
       get: {
         summary: "List routes",
         responses: {
@@ -51,7 +51,7 @@ export const openApiSpec = {
         },
       },
     },
-    "/routes/{routeId}": {
+    "/v1/routes/{routeId}": {
       get: {
         summary: "Get route details",
         parameters: [
@@ -68,7 +68,7 @@ export const openApiSpec = {
         },
       },
     },
-    "/routes/{routeId}/finish": {
+    "/v1/routes/{routeId}/finish": {
       post: {
         summary: "Finish route",
         parameters: [
@@ -82,7 +82,7 @@ export const openApiSpec = {
         responses: { "200": { description: "OK" } },
       },
     },
-    "/jobs/{jobId}/routes": {
+    "/v1/jobs/{jobId}/routes": {
       get: {
         summary: "List routes for job",
         parameters: [
@@ -99,7 +99,7 @@ export const openApiSpec = {
         },
       },
     },
-    "/favourites": {
+    "/v1/favourites": {
       get: {
         summary: "List favourites",
         responses: { "200": { description: "OK" } },
@@ -109,7 +109,7 @@ export const openApiSpec = {
         responses: { "200": { description: "OK" } },
       },
     },
-    "/favourites/{routeId}": {
+    "/v1/favourites/{routeId}": {
       delete: {
         summary: "Remove favourite",
         parameters: [
@@ -123,7 +123,7 @@ export const openApiSpec = {
         responses: { "200": { description: "OK" } },
       },
     },
-    "/profile": {
+    "/v1/profile": {
       get: {
         summary: "Get profile",
         responses: { "200": { description: "OK" } },
@@ -133,7 +133,7 @@ export const openApiSpec = {
         responses: { "200": { description: "OK" } },
       },
     },
-    "/telemetry/started": {
+    "/v1/telemetry/started": {
       post: {
         summary: "Start telemetry",
         responses: { "200": { description: "OK" } },

--- a/src/backend/src/routes/interfaces/http/page-router.test.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.test.ts
@@ -74,7 +74,7 @@ beforeEach(() => {
 describe("page router get route", () => {
   const baseEvent = {
     ...baseCtx,
-    resource: "/routes/{routeId}",
+    resource: "/v1/routes/{routeId}",
     httpMethod: "GET",
   } as any;
 
@@ -128,7 +128,7 @@ describe("page router get route", () => {
 describe("page router list routes", () => {
   const baseEvent = {
     ...baseCtx,
-    resource: "/routes",
+    resource: "/v1/routes",
     httpMethod: "GET",
   } as any;
 
@@ -194,7 +194,7 @@ describe("page router list routes", () => {
 describe("page router list routes by jobId", () => {
   const baseEvent = {
     ...baseCtx,
-    resource: "/jobs/{jobId}/routes",
+    resource: "/v1/jobs/{jobId}/routes",
     httpMethod: "GET",
   } as any;
 
@@ -229,7 +229,7 @@ describe("page router list routes by jobId", () => {
 describe("telemetry started", () => {
   const baseEvent = {
     ...baseCtx,
-    resource: "/telemetry/started",
+    resource: "/v1/telemetry/started",
     httpMethod: "POST",
   } as any;
 
@@ -282,7 +282,7 @@ describe("telemetry started", () => {
 describe("finish route", () => {
   const baseEvent = {
     ...baseCtx,
-    resource: "/routes/{routeId}/finish",
+    resource: "/v1/routes/{routeId}/finish",
     httpMethod: "POST",
   } as any;
 

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -108,8 +108,8 @@ export const handler = async (
       body: JSON.stringify({ error: "Unauthorized" }),
     };
   }
-  // GET /routes
-  if (httpMethod === "GET" && resource === "/routes") {
+  // GET /v1/routes
+  if (httpMethod === "GET" && resource === "/v1/routes") {
     try {
       const all = await listRoutes.execute();
       return {
@@ -135,8 +135,8 @@ export const handler = async (
     }
   }
 
-  // GET /routes/{routeId}
-  if (httpMethod === "GET" && resource === "/routes/{routeId}") {
+  // GET /v1/routes/{routeId}
+  if (httpMethod === "GET" && resource === "/v1/routes/{routeId}") {
     const routeId = pathParameters?.routeId;
     if (!routeId) {
       return {
@@ -182,8 +182,8 @@ export const handler = async (
     };
   }
 
-  // GET /jobs/{jobId}/routes
-  if (httpMethod === "GET" && resource === "/jobs/{jobId}/routes") {
+  // GET /v1/jobs/{jobId}/routes
+  if (httpMethod === "GET" && resource === "/v1/jobs/{jobId}/routes") {
     const jobId = pathParameters?.jobId;
     if (!jobId) {
       return {
@@ -217,7 +217,7 @@ export const handler = async (
     }
   }
 
-  if (resource === "/telemetry/started" && httpMethod === "POST") {
+  if (resource === "/v1/telemetry/started" && httpMethod === "POST") {
     let payload: any = {};
     if (event.body) {
       try {
@@ -261,7 +261,7 @@ export const handler = async (
     };
   }
 
-  if (resource === "/routes/{routeId}/finish" && httpMethod === "POST") {
+  if (resource === "/v1/routes/{routeId}/finish" && httpMethod === "POST") {
     const routeId = pathParameters?.routeId;
     if (!routeId) {
       return {

--- a/src/frontend/src/pages/FavouritesPage.tsx
+++ b/src/frontend/src/pages/FavouritesPage.tsx
@@ -89,12 +89,12 @@ const FavouritesPage = () => {
   useEffect(() => {
     const fetchFavs = async () => {
       try {
-        const { data } = await api.get('/favourites');
+        const { data } = await api.get('/v1/favourites');
         const ids: string[] = data.favourites || [];
         const details: RouteDetails[] = await Promise.all(
           ids.map(async (id: string) => {
             try {
-              const { data } = await api.get(`/routes/${id}`);
+              const { data } = await api.get(`/v1/routes/${id}`);
               return data as RouteDetails;
             } catch {
               return { routeId: id };
@@ -114,7 +114,7 @@ const FavouritesPage = () => {
 
   const handleRemove = async (id: string) => {
     try {
-      await api.delete(`/favourites/${id}`);
+      await api.delete(`/v1/favourites/${id}`);
       setFavourites((prev) => prev.filter((f) => f.routeId !== id));
       toast({ title: 'Route removed from favourites', status: 'info' });
     } catch (err) {

--- a/src/frontend/src/pages/RouteDetailPage.tsx
+++ b/src/frontend/src/pages/RouteDetailPage.tsx
@@ -124,7 +124,7 @@ export default function RouteDetailPage() {
   useEffect(() => {
     if (!routeId) return;
     api
-      .get(`/routes/${routeId}`)
+      .get(`/v1/routes/${routeId}`)
       .then(({ data }) => setRoute(data))
       .catch(console.error)
       .finally(() => setLoading(false));
@@ -134,7 +134,7 @@ export default function RouteDetailPage() {
     if (!routeId) return;
     (async () => {
       try {
-        const { data } = await api.get('/favourites');
+        const { data } = await api.get('/v1/favourites');
         const ids: string[] = data.favourites || [];
         setFavCount(ids.length);
         setIsFav(ids.includes(routeId));
@@ -249,12 +249,12 @@ export default function RouteDetailPage() {
     setFavBusy(true);
     try {
       if (isFav) {
-        await api.delete(`/favourites/${routeId}`);
+        await api.delete(`/v1/favourites/${routeId}`);
         setIsFav(false);
         setFavCount((c) => Math.max(0, c - 1));
         toast({ title: 'Removed from favourites', status: 'info' });
       } else {
-        await api.post('/favourites', { routeId });
+        await api.post('/v1/favourites', { routeId });
         setIsFav(true);
         setFavCount((c) => c + 1);
 
@@ -280,7 +280,7 @@ export default function RouteDetailPage() {
   const handleStart = async () => {
     if (!routeId) return;
     try {
-      await api.post('/telemetry/started', { routeId });
+      await api.post('/v1/telemetry/started', { routeId });
     } catch (err) {
       console.error(err);
       toast({ title: 'Failed to start tracking', status: 'error' });
@@ -328,7 +328,7 @@ export default function RouteDetailPage() {
   const handleFinish = async () => {
     if (!routeId) return;
     try {
-      const { data } = await api.post(`/routes/${routeId}/finish`);
+      const { data } = await api.post(`/v1/routes/${routeId}/finish`);
       if (watchId !== null) navigator.geolocation.clearWatch(watchId);
       setWatchId(null);
       setPosition(null);

--- a/src/frontend/src/pages/RoutesPage.tsx
+++ b/src/frontend/src/pages/RoutesPage.tsx
@@ -118,7 +118,7 @@ export default function RoutesPage() {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get('/favourites');
+        const { data } = await api.get('/v1/favourites');
         setFavourites(data.favourites || []);
       } catch {}
     })();
@@ -154,7 +154,7 @@ export default function RoutesPage() {
   useEffect(() => {
     if (!jobId) return;
     const iv = setInterval(async () => {
-      const { data } = await api.get(`/jobs/${jobId}/routes`);
+      const { data } = await api.get(`/v1/jobs/${jobId}/routes`);
       if (data.length) {
         setRoutes(data);
         setLoading(false);
@@ -235,7 +235,7 @@ export default function RoutesPage() {
 
     setLoading(true);
     try {
-      const { data } = await api.post('/routes', payload);
+      const { data } = await api.post('/v1/routes', payload);
       setJobId(data.jobId);
       toast({ title: 'Route request submitted.', status: 'success' });
     } catch (err: unknown) {
@@ -317,10 +317,10 @@ export default function RoutesPage() {
 
     try {
       if (isFav) {
-        await api.delete(`/favourites/${routeId}`);
+        await api.delete(`/v1/favourites/${routeId}`);
         setFavourites((prev) => prev.filter((id) => id !== routeId));
       } else {
-        await api.post('/favourites', { routeId });
+        await api.post('/v1/favourites', { routeId });
         setFavourites((prev) => [...prev, routeId]);
       }
     } catch {
@@ -335,7 +335,7 @@ export default function RoutesPage() {
   const handleStartClick = async (routeId: string, navState?: any) => {
     setStartingRouteId(routeId);
     try {
-      await api.get(`/routes/${routeId}`);
+      await api.get(`/v1/routes/${routeId}`);
     } catch {}
     navigate(`/routes/${routeId}`, { state: navState });
   };

--- a/src/frontend/src/pages/UserProfilePage.tsx
+++ b/src/frontend/src/pages/UserProfilePage.tsx
@@ -43,7 +43,7 @@ const UserProfilePage = () => {
   useEffect(() => {
     const fetchProfile = async () => {
       try {
-        const { data } = await api.get('/profile');
+        const { data } = await api.get('/v1/profile');
         setProfile(data);
         setForm(data);
       } finally {
@@ -68,7 +68,7 @@ const UserProfilePage = () => {
     if (!form) return;
     setSaving(true);
     try {
-      await api.put('/profile', form);
+      await api.put('/v1/profile', form);
       setProfile(form);
       toast({
         title: 'Profile updated.',


### PR DESCRIPTION
## Summary
- prefix all API Gateway routes with `/v1`
- adjust page router to expect `/v1` paths
- update OpenAPI spec and frontend clients to call versioned endpoints

## Testing
- `npm run test:unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd45cd52a8832fa33ed941b0cc240a