### PR TITLE
Add request trace IDs and include in error responses

### DIFF
--- a/src/backend/src/docs/interfaces/http/swagger.ts
+++ b/src/backend/src/docs/interfaces/http/swagger.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { openApiSpec } from "../../openapi";
 import { corsHeaders } from "../../../http/cors";
+import { base } from "../../../http/base";
 
 const html = `<!DOCTYPE html>
 <html>
@@ -26,7 +27,7 @@ const html = `<!DOCTYPE html>
   </body>
 </html>`;
 
-export const handler = async (
+export const handler = base(async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   if (event.path.endsWith("/swagger.json")) {
@@ -42,4 +43,4 @@ export const handler = async (
     headers: { ...corsHeaders, "Content-Type": "text/html" },
     body: html,
   };
-};
+});

--- a/src/backend/src/http/base.ts
+++ b/src/backend/src/http/base.ts
@@ -1,0 +1,26 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { AsyncLocalStorage } from "async_hooks";
+import { UUID } from "../shared/domain/value-objects/uuid";
+
+const storage = new AsyncLocalStorage<{ traceId: string }>();
+
+export const getTraceId = (): string | undefined => {
+  return storage.getStore()?.traceId;
+};
+
+type Handler = (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>;
+
+export const base = (handler: Handler): Handler => {
+  return async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const traceId = UUID.generate().Value;
+    return storage.run({ traceId }, async () => {
+      console.log(`traceId:${traceId}`);
+      try {
+        return await handler(event);
+      } catch (err) {
+        console.error(`traceId:${traceId}`, err);
+        throw err;
+      }
+    });
+  };
+};

--- a/src/backend/src/http/error-response.ts
+++ b/src/backend/src/http/error-response.ts
@@ -1,5 +1,6 @@
 import { APIGatewayProxyResult } from "aws-lambda";
 import { corsHeaders } from "./cors";
+import { getTraceId } from "./base";
 
 export function errorResponse(
   code: number,
@@ -7,6 +8,11 @@ export function errorResponse(
   details?: unknown
 ): APIGatewayProxyResult {
   const body: Record<string, unknown> = { code, message };
+  const traceId = getTraceId();
+  if (traceId) {
+    body.traceId = traceId;
+    console.error(`traceId:${traceId} error:${message}`);
+  }
   if (details !== undefined) {
     body.details = details;
   }

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -13,6 +13,7 @@ import { StartRouteUseCase } from "../../application/use-cases/start-route";
 import { FinishRouteUseCase } from "../../application/use-cases/finish-route";
 import { corsHeaders } from "../../../http/cors";
 import { errorResponse } from "../../../http/error-response";
+import { base } from "../../../http/base";
 import { getGoogleKey } from "../shared/utils";
 import { GoogleMapsProvider } from "../../infrastructure/google-maps/google-maps-provider";
 import {
@@ -98,7 +99,7 @@ const describeRouteUseCase = new DescribeRouteUseCase(
 const startRouteUseCase = new StartRouteUseCase(routeRepository, dispatcher);
 const finishRouteUseCase = new FinishRouteUseCase(routeRepository, dispatcher);
 
-export const handler = async (
+export const handler = base(async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   const { httpMethod, resource, pathParameters } = event;
@@ -283,4 +284,4 @@ export const handler = async (
   }
 
   return errorResponse(501, "Not Implemented");
-};
+});

--- a/src/backend/src/routes/interfaces/http/request-routes.test.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.test.ts
@@ -52,7 +52,7 @@ describe("request routes handler", () => {
   it("returns 400 when body parsing fails", async () => {
     const res = await handler({ body: '{"invalid"' } as any);
     expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body)).toEqual({
+    expect(JSON.parse(res.body)).toMatchObject({
       code: 400,
       message: "Invalid JSON body",
     });
@@ -63,13 +63,13 @@ describe("request routes handler", () => {
     mockSend.mockResolvedValueOnce({});
     const res1 = await handler({ body: JSON.stringify({ destination: "B" }) } as any);
     expect(res1.statusCode).toBe(400);
-    expect(JSON.parse(res1.body)).toEqual({
+    expect(JSON.parse(res1.body)).toMatchObject({
       code: 400,
       message: "Must provide origin and (destination OR distanceKm)",
     });
     const res2 = await handler({ body: JSON.stringify({ origin: "A" }) } as any);
     expect(res2.statusCode).toBe(400);
-    expect(JSON.parse(res2.body)).toEqual({
+    expect(JSON.parse(res2.body)).toMatchObject({
       code: 400,
       message: "Must provide origin and (destination OR distanceKm)",
     });

--- a/src/backend/src/routes/interfaces/http/request-routes.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.ts
@@ -3,10 +3,11 @@ import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 import { UUID } from "../../../shared/domain/value-objects/uuid";
 import { corsHeaders } from "../../../http/cors";
 import { errorResponse } from "../../../http/error-response";
+import { base } from "../../../http/base";
 
 const sqs = new SQSClient({});
 
-export const handler = async (
+export const handler = base(async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   let data: any = {};
@@ -66,4 +67,4 @@ export const handler = async (
     headers: corsHeaders,
     body: JSON.stringify({ enqueued: true, jobId: data.jobId }),
   };
-};
+});

--- a/src/backend/src/users/interfaces/http/favourite-routes.ts
+++ b/src/backend/src/users/interfaces/http/favourite-routes.ts
@@ -9,6 +9,7 @@ import { AddFavouriteUseCase, FavouriteAlreadyExistsError } from "../../applicat
 import { RemoveFavouriteUseCase } from "../../application/use-cases/remove-favourite";
 import { corsHeaders } from "../../../http/cors";
 import { errorResponse } from "../../../http/error-response";
+import { base } from "../../../http/base";
 import { Email } from "../../../shared/domain/value-objects/email";
 import { hasScope, Scope } from "../../../auth/scopes";
 
@@ -22,7 +23,7 @@ const repository = new DynamoUserProfileRepository(
 const addFavourite = new AddFavouriteUseCase(repository);
 const removeFavourite = new RemoveFavouriteUseCase(repository);
 
-export const handler = async (
+export const handler = base(async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   const claims = (event.requestContext as any).authorizer?.claims;
@@ -88,4 +89,4 @@ export const handler = async (
   }
 
   return errorResponse(501, "Not Implemented");
-};
+});

--- a/src/backend/src/users/interfaces/http/profile-routes.ts
+++ b/src/backend/src/users/interfaces/http/profile-routes.ts
@@ -8,6 +8,7 @@ import { UserProfile } from "../../domain/entities/user-profile";
 import { corsHeaders } from "../../../http/cors";
 import { hasScope, Scope } from "../../../auth/scopes";
 import { errorResponse } from "../../../http/error-response";
+import { base } from "../../../http/base";
 
 const dynamo = new DynamoDBClient({
   endpoint: process.env.AWS_ENDPOINT_URL_DYNAMODB,
@@ -19,7 +20,7 @@ const repository = new DynamoUserProfileRepository(
 const getUserProfile = new GetUserProfileUseCase(repository);
 const updateUserProfile = new UpdateUserProfileUseCase(repository);
 
-export const handler = async (
+export const handler = base(async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   const claims = (event.requestContext as any).authorizer?.claims;
@@ -59,4 +60,4 @@ export const handler = async (
   }
 
   return errorResponse(501, "Not Implemented");
-};
+});

--- a/src/backend/test/integration/favourite-routes.integration.test.ts
+++ b/src/backend/test/integration/favourite-routes.integration.test.ts
@@ -84,7 +84,7 @@ describe("favourite routes integration", () => {
     });
 
     expect(res.statusCode).toBe(409);
-    expect(JSON.parse(res.body)).toEqual({
+    expect(JSON.parse(res.body)).toMatchObject({
       code: 409,
       message: "Route already in favourites",
     });
@@ -108,6 +108,9 @@ describe("favourite routes integration", () => {
     const res = await handler({ httpMethod: "GET", requestContext: {} as any });
 
     expect(res.statusCode).toBe(401);
-    expect(JSON.parse(res.body)).toEqual({ code: 401, message: "Unauthorized" });
+    expect(JSON.parse(res.body)).toMatchObject({
+      code: 401,
+      message: "Unauthorized",
+    });
   });
 });

--- a/src/backend/test/integration/profile-routes.integration.test.ts
+++ b/src/backend/test/integration/profile-routes.integration.test.ts
@@ -85,7 +85,10 @@ describe("profile routes integration", () => {
     const res = await handler({ httpMethod: "GET", requestContext: {} as any });
 
     expect(res.statusCode).toBe(401);
-    expect(JSON.parse(res.body)).toEqual({ code: 401, message: "Unauthorized" });
+    expect(JSON.parse(res.body)).toMatchObject({
+      code: 401,
+      message: "Unauthorized",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- generate per-request trace ID via new base middleware
- log trace IDs and attach them to error responses
- update handlers and tests for trace-aware responses

## Testing
- `npm --prefix src/backend run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68bd4c4cb71c832f8c4131c4a04569d1