### PR TITLE
feat(auth): log signup and login events

### DIFF
--- a/src/backend/src/auth/triggers/post-authentication.test.ts
+++ b/src/backend/src/auth/triggers/post-authentication.test.ts
@@ -1,0 +1,53 @@
+const sendMock = jest.fn();
+
+jest.mock(
+  "@aws-sdk/client-cloudwatch",
+  () => ({
+    CloudWatchClient: jest.fn().mockImplementation(() => ({ send: sendMock })),
+    PutMetricDataCommand: jest.fn().mockImplementation((input) => ({ input })),
+  }),
+  { virtual: true }
+);
+
+import type { PostAuthenticationTriggerEvent } from "aws-lambda";
+
+function createEvent(): PostAuthenticationTriggerEvent {
+  return {
+    version: "1",
+    region: "us-east-1",
+    userPoolId: "pool",
+    userName: "user",
+    triggerSource: "PostAuthentication_Authentication",
+    callerContext: {} as any,
+    request: {
+      userAttributes: {},
+      newDeviceUsed: false,
+      clientMetadata: {},
+    },
+    response: {},
+  } as any;
+}
+
+describe("post-authentication trigger", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    process.env.METRICS_NAMESPACE = "TestNS";
+  });
+
+  it("logs and publishes metric", async () => {
+    const { handler } = require("./post-authentication");
+    const consoleSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    await handler(createEvent());
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(consoleSpy.mock.calls[0][0]).toContain("UserLoggedIn");
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const call = sendMock.mock.calls[0][0];
+    expect(call.input.Namespace).toBe("TestNS");
+    expect(call.input.MetricData).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ MetricName: "UserLoggedIn", Value: 1, Unit: "Count" }),
+      ])
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/backend/src/auth/triggers/post-authentication.ts
+++ b/src/backend/src/auth/triggers/post-authentication.ts
@@ -1,0 +1,25 @@
+import type { Handler, PostAuthenticationTriggerEvent } from "aws-lambda";
+import { CloudWatchClient, PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+
+const cw = new CloudWatchClient({});
+
+export const handler: Handler<PostAuthenticationTriggerEvent, PostAuthenticationTriggerEvent> = async (
+  event
+) => {
+  console.info("[post-authentication] UserLoggedIn", event.userName);
+  const namespace = process.env.METRICS_NAMESPACE!;
+  await cw.send(
+    new PutMetricDataCommand({
+      Namespace: namespace,
+      MetricData: [
+        {
+          MetricName: "UserLoggedIn",
+          Value: 1,
+          Unit: "Count",
+          Timestamp: new Date(),
+        },
+      ],
+    })
+  );
+  return event;
+};

--- a/src/backend/src/auth/triggers/post-confirmation.test.ts
+++ b/src/backend/src/auth/triggers/post-confirmation.test.ts
@@ -1,0 +1,52 @@
+const sendMock = jest.fn();
+
+jest.mock(
+  "@aws-sdk/client-cloudwatch",
+  () => ({
+    CloudWatchClient: jest.fn().mockImplementation(() => ({ send: sendMock })),
+    PutMetricDataCommand: jest.fn().mockImplementation((input) => ({ input })),
+  }),
+  { virtual: true }
+);
+
+import type { PostConfirmationTriggerEvent } from "aws-lambda";
+
+function createEvent(): PostConfirmationTriggerEvent {
+  return {
+    version: "1",
+    region: "us-east-1",
+    userPoolId: "pool",
+    userName: "user",
+    triggerSource: "PostConfirmation_ConfirmSignUp",
+    callerContext: {} as any,
+    request: {
+      userAttributes: {},
+      clientMetadata: {},
+    },
+    response: {},
+  } as any;
+}
+
+describe("post-confirmation trigger", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    process.env.METRICS_NAMESPACE = "TestNS";
+  });
+
+  it("logs and publishes metric", async () => {
+    const { handler } = require("./post-confirmation");
+    const consoleSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    await handler(createEvent());
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(consoleSpy.mock.calls[0][0]).toContain("UserSignedUp");
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const call = sendMock.mock.calls[0][0];
+    expect(call.input.Namespace).toBe("TestNS");
+    expect(call.input.MetricData).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ MetricName: "UserSignedUp", Value: 1, Unit: "Count" }),
+      ])
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/backend/src/auth/triggers/post-confirmation.ts
+++ b/src/backend/src/auth/triggers/post-confirmation.ts
@@ -1,0 +1,25 @@
+import type { Handler, PostConfirmationTriggerEvent } from "aws-lambda";
+import { CloudWatchClient, PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+
+const cw = new CloudWatchClient({});
+
+export const handler: Handler<PostConfirmationTriggerEvent, PostConfirmationTriggerEvent> = async (
+  event
+) => {
+  console.info("[post-confirmation] UserSignedUp", event.userName);
+  const namespace = process.env.METRICS_NAMESPACE!;
+  await cw.send(
+    new PutMetricDataCommand({
+      Namespace: namespace,
+      MetricData: [
+        {
+          MetricName: "UserSignedUp",
+          Value: 1,
+          Unit: "Count",
+          Timestamp: new Date(),
+        },
+      ],
+    })
+  );
+  return event;
+};


### PR DESCRIPTION
## Summary
- add post-confirmation trigger to log signups and emit CloudWatch metrics
- add post-authentication trigger to log logins and emit CloudWatch metrics

## Testing
- `npm run test:unit`
- `npm run build` *(fails: Cannot assign to 'duration' because it is a read-only property, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bd57fc182c832f903a7fa265455bce