### PR TITLE
feat(cache): add cache cleaner cron

### DIFF
--- a/src/backend/src/routes/domain/events/cache-expired.ts
+++ b/src/backend/src/routes/domain/events/cache-expired.ts
@@ -1,0 +1,15 @@
+import { DomainEvent } from "../../../shared/domain/events/domain-event";
+
+export interface CacheExpiredProps {
+  readonly count: number;
+}
+
+export class CacheExpiredEvent extends DomainEvent {
+  readonly eventName = "CacheExpired";
+  readonly count: number;
+
+  constructor(props: CacheExpiredProps) {
+    super();
+    this.count = props.count;
+  }
+}

--- a/src/backend/src/routes/interfaces/cron/cache-cleaner.test.ts
+++ b/src/backend/src/routes/interfaces/cron/cache-cleaner.test.ts
@@ -1,0 +1,67 @@
+const ddbSendMock = jest.fn();
+const sqsSendMock = jest.fn();
+const cwSendMock = jest.fn();
+
+jest.mock(
+  "@aws-sdk/client-dynamodb",
+  () => ({
+    DynamoDBClient: jest.fn().mockImplementation(() => ({ send: ddbSendMock })),
+    ScanCommand: jest.fn().mockImplementation((input) => ({ input })),
+    DeleteItemCommand: jest.fn().mockImplementation((input) => ({ input })),
+  }),
+  { virtual: true }
+);
+jest.mock(
+  "@aws-sdk/client-sqs",
+  () => ({
+    SQSClient: jest.fn().mockImplementation(() => ({ send: sqsSendMock })),
+    SendMessageCommand: jest.fn().mockImplementation((input) => ({ input })),
+  }),
+  { virtual: true }
+);
+jest.mock(
+  "@aws-sdk/client-cloudwatch",
+  () => ({
+    CloudWatchClient: jest.fn().mockImplementation(() => ({ send: cwSendMock })),
+    PutMetricDataCommand: jest.fn().mockImplementation((input) => ({ input })),
+  }),
+  { virtual: true }
+);
+
+describe("cache cleaner", () => {
+  beforeEach(() => {
+    ddbSendMock.mockReset();
+    sqsSendMock.mockReset();
+    cwSendMock.mockReset();
+    process.env.ROUTES_TABLE = "routes";
+    process.env.METRICS_QUEUE = "queue";
+    process.env.METRICS_NAMESPACE = "TestNS";
+  });
+
+  it("removes expired items and publishes metrics", async () => {
+    ddbSendMock.mockResolvedValueOnce({
+      Items: [{ routeId: { S: "r1" } }, { routeId: { S: "r2" } }],
+    });
+    const { handler } = require("./cache-cleaner");
+    await handler();
+
+    // should delete both items
+    expect(ddbSendMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ TableName: "routes" }),
+      })
+    );
+    // send metric
+    expect(cwSendMock).toHaveBeenCalledTimes(1);
+    const metricCall = cwSendMock.mock.calls[0][0].input;
+    expect(metricCall.Namespace).toBe("TestNS");
+    expect(metricCall.MetricData[0].MetricName).toBe("CacheExpired");
+    expect(metricCall.MetricData[0].Value).toBe(2);
+    // send event message
+    expect(sqsSendMock).toHaveBeenCalledTimes(1);
+    const msg = sqsSendMock.mock.calls[0][0].input.MessageBody;
+    expect(JSON.parse(msg)).toEqual(
+      expect.objectContaining({ event: "CacheExpired", count: 2 })
+    );
+  });
+});

--- a/src/backend/src/routes/interfaces/cron/cache-cleaner.ts
+++ b/src/backend/src/routes/interfaces/cron/cache-cleaner.ts
@@ -1,0 +1,73 @@
+import { DynamoDBClient, ScanCommand, DeleteItemCommand } from "@aws-sdk/client-dynamodb";
+import { CloudWatchClient, PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { InMemoryEventDispatcher } from "../../../shared/domain/events/event-dispatcher";
+import { CacheExpiredEvent } from "../../domain/events/cache-expired";
+
+const dynamo = new DynamoDBClient({
+  endpoint: process.env.AWS_ENDPOINT_URL_DYNAMODB,
+});
+const cw = new CloudWatchClient({});
+const sqs = new SQSClient({});
+
+const dispatcher = new InMemoryEventDispatcher();
+
+dispatcher.subscribe("CacheExpired", async (event: CacheExpiredEvent) => {
+  const timestamp = event.occurredAt;
+  if (process.env.METRICS_QUEUE) {
+    await sqs.send(
+      new SendMessageCommand({
+        QueueUrl: process.env.METRICS_QUEUE!,
+        MessageBody: JSON.stringify({
+          event: "CacheExpired",
+          count: event.count,
+          timestamp: timestamp.toISOString(),
+        }),
+      })
+    );
+  }
+  await cw.send(
+    new PutMetricDataCommand({
+      Namespace: process.env.METRICS_NAMESPACE!,
+      MetricData: [
+        {
+          MetricName: "CacheExpired",
+          Value: event.count,
+          Unit: "Count",
+          Timestamp: timestamp,
+        },
+      ],
+    })
+  );
+});
+
+export const handler = async () => {
+  const table = process.env.ROUTES_TABLE!;
+  const now = Math.floor(Date.now() / 1000);
+  const res = await dynamo.send(
+    new ScanCommand({
+      TableName: table,
+      FilterExpression: "ttl <= :now",
+      ExpressionAttributeValues: { ":now": { N: now.toString() } },
+      ProjectionExpression: "routeId",
+    })
+  );
+  const items = res.Items || [];
+  for (const item of items) {
+    const routeId = item.routeId?.S;
+    if (!routeId) continue;
+    try {
+      await dynamo.send(
+        new DeleteItemCommand({
+          TableName: table,
+          Key: { routeId: { S: routeId } },
+        })
+      );
+    } catch (err) {
+      console.error("[cache-cleaner] error deleting", routeId, err);
+    }
+  }
+  if (items.length) {
+    await dispatcher.publish(new CacheExpiredEvent({ count: items.length }));
+  }
+};


### PR DESCRIPTION
## Summary
- add CacheExpired domain event
- add cron job to delete expired cache items and record metrics

## Testing
- `npm --prefix src/backend run test:unit | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bd57fef434832f9e5a8d9077403299