### PR TITLE
feat: emit ErrorOccurred events for SQS worker failures

### DIFF
--- a/src/backend/src/routes/interfaces/appsync-client.test.ts
+++ b/src/backend/src/routes/interfaces/appsync-client.test.ts
@@ -1,7 +1,7 @@
 process.env.APPSYNC_URL = 'https://example.com/graphql';
 process.env.APPSYNC_API_KEY = 'test-key';
 
-import { publishFavouriteSaved, publishFavouriteDeleted, publishRoutesGenerated, publishRouteStarted, publishRouteFinished } from './appsync-client';
+import { publishFavouriteSaved, publishFavouriteDeleted, publishRoutesGenerated, publishRouteStarted, publishRouteFinished, publishErrorOccurred } from './appsync-client';
 import { RouteStatus } from '../domain/value-objects/route-status';
 import { Route } from '../domain/entities/route';
 import { UUID } from '../../shared/domain/value-objects/uuid';
@@ -88,6 +88,16 @@ describe('appsync-client', () => {
     expect(body).toEqual({
       query: `mutation PublishRouteFinished($email: String!, $routeId: ID!, $summary: String!) {\n  publishRouteFinished(email: $email, routeId: $routeId, summary: $summary)\n}`,
       variables: { email: 'user@example.com', routeId: 'route-1', summary: 'summary' },
+    });
+  });
+
+  it('publishErrorOccurred sends correct payload', async () => {
+    await publishErrorOccurred('boom', { foo: 'bar' });
+    const [, opts] = fetchMock.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({
+      query: `mutation PublishErrorOccurred($message: String!, $payload: AWSJSON) {\n  publishErrorOccurred(message: $message, payload: $payload)\n}`,
+      variables: { message: 'boom', payload: { foo: 'bar' } },
     });
   });
 });

--- a/src/backend/src/routes/interfaces/appsync-client.ts
+++ b/src/backend/src/routes/interfaces/appsync-client.ts
@@ -93,3 +93,13 @@ export async function publishRouteFinished(
     { email, routeId, summary }
   );
 }
+
+export async function publishErrorOccurred(
+  message: string,
+  payload: any
+) {
+  await send(
+    `mutation PublishErrorOccurred($message: String!, $payload: AWSJSON) {\n  publishErrorOccurred(message: $message, payload: $payload)\n}`,
+    { message, payload }
+  );
+}


### PR DESCRIPTION
## Summary
- publish `ErrorOccurred` via AppSync client
- catch map API failures in `worker-routes` and emit error events
- add tests for error publishing

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68bd58009b20832fab9d6edc86247224