### PR TITLE
feat: add telemetry for route start and finish

### DIFF
--- a/src/backend/src/routes/interfaces/telemetry/route-events-subscriber.test.ts
+++ b/src/backend/src/routes/interfaces/telemetry/route-events-subscriber.test.ts
@@ -2,6 +2,8 @@ import { registerTelemetrySubscribers } from "./route-events-subscriber";
 import { EventDispatcher } from "../../../shared/domain/events/event-dispatcher";
 import { RouteRequestedEvent } from "../../domain/events/route-requested";
 import { RouteGeneratedEvent } from "../../domain/events/route-generated";
+import { RouteStartedEvent } from "../../domain/events/route-started";
+import { RouteFinishedEvent } from "../../domain/events/route-finished";
 import { RouteStatus } from "../../domain/value-objects/route-status";
 import { UUID } from "../../../shared/domain/value-objects/uuid";
 import { Route } from "../../domain/entities/route";
@@ -29,12 +31,16 @@ describe("registerTelemetrySubscribers", () => {
   it("logs telemetry when route events are dispatched", () => {
     registerTelemetrySubscribers(dispatcher);
 
-    expect(subscribe).toHaveBeenCalledTimes(2);
+    expect(subscribe).toHaveBeenCalledTimes(4);
     const [requestedEventName, requestedHandler] = subscribe.mock.calls[0];
     const [generatedEventName, generatedHandler] = subscribe.mock.calls[1];
+    const [startedEventName, startedHandler] = subscribe.mock.calls[2];
+    const [finishedEventName, finishedHandler] = subscribe.mock.calls[3];
 
     expect(requestedEventName).toBe("RouteRequested");
     expect(generatedEventName).toBe("RouteGenerated");
+    expect(startedEventName).toBe("RouteStarted");
+    expect(finishedEventName).toBe("RouteFinished");
 
     const routeId = UUID.generate();
     requestedHandler(new RouteRequestedEvent({ routeId }));
@@ -44,12 +50,49 @@ describe("registerTelemetrySubscribers", () => {
       routeId.Value
     );
 
-    const route = Route.rehydrate({ routeId, status: RouteStatus.Generated });
-    generatedHandler(new RouteGeneratedEvent({ route }));
+    const generatedRoute = Route.rehydrate({ routeId, status: RouteStatus.Generated });
+    generatedHandler(new RouteGeneratedEvent({ route: generatedRoute }));
     expect(consoleSpy).toHaveBeenNthCalledWith(
       2,
       "Telemetry: route generated",
-      route.routeId.Value
+      generatedRoute.routeId.Value
+    );
+
+    const startTimestamp = 1;
+    const startedRoute = Route.rehydrate({ routeId, status: RouteStatus.Started });
+    startedHandler(
+      new RouteStartedEvent({
+        route: startedRoute,
+        email: "user@example.com",
+        timestamp: startTimestamp,
+      })
+    );
+    expect(consoleSpy).toHaveBeenNthCalledWith(
+      3,
+      "Telemetry: route started",
+      startedRoute.routeId.Value,
+      "user@example.com",
+      startTimestamp
+    );
+
+    const finishTimestamp = 2;
+    const actualDuration = 1;
+    const finishedRoute = Route.rehydrate({ routeId, status: RouteStatus.Finished });
+    finishedHandler(
+      new RouteFinishedEvent({
+        route: finishedRoute,
+        email: "user@example.com",
+        timestamp: finishTimestamp,
+        actualDuration,
+      })
+    );
+    expect(consoleSpy).toHaveBeenNthCalledWith(
+      4,
+      "Telemetry: route finished",
+      finishedRoute.routeId.Value,
+      "user@example.com",
+      finishTimestamp,
+      actualDuration
     );
   });
 });

--- a/src/backend/src/routes/interfaces/telemetry/route-events-subscriber.ts
+++ b/src/backend/src/routes/interfaces/telemetry/route-events-subscriber.ts
@@ -1,6 +1,8 @@
 import { EventDispatcher } from "../../../shared/domain/events/event-dispatcher";
 import { RouteRequestedEvent } from "../../domain/events/route-requested";
 import { RouteGeneratedEvent } from "../../domain/events/route-generated";
+import { RouteStartedEvent } from "../../domain/events/route-started";
+import { RouteFinishedEvent } from "../../domain/events/route-finished";
 
 export function registerTelemetrySubscribers(dispatcher: EventDispatcher): void {
   dispatcher.subscribe("RouteRequested", (event: RouteRequestedEvent) => {
@@ -8,5 +10,22 @@ export function registerTelemetrySubscribers(dispatcher: EventDispatcher): void 
   });
   dispatcher.subscribe("RouteGenerated", (event: RouteGeneratedEvent) => {
     console.log("Telemetry: route generated", event.route.routeId.Value);
+  });
+  dispatcher.subscribe("RouteStarted", (event: RouteStartedEvent) => {
+    console.log(
+      "Telemetry: route started",
+      event.route.routeId.Value,
+      event.email,
+      event.timestamp
+    );
+  });
+  dispatcher.subscribe("RouteFinished", (event: RouteFinishedEvent) => {
+    console.log(
+      "Telemetry: route finished",
+      event.route.routeId.Value,
+      event.email,
+      event.timestamp,
+      event.actualDuration
+    );
   });
 }


### PR DESCRIPTION
## Summary
- log route start and finish events with user email, timestamp and duration
- cover new telemetry events in unit tests

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68bd580219b4832f986aa0a5310e5432