### PR TITLE
feat: track active route with ttl

### DIFF
--- a/src/backend/src/routes/interfaces/http/page-router.test.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.test.ts
@@ -2,9 +2,9 @@ const mockFindById = jest.fn();
 const mockFindAll = jest.fn();
 const mockFindByJobId = jest.fn();
 const mockSave = jest.fn();
-const mockPutRouteStart = jest.fn();
-const mockGetRouteStart = jest.fn();
-const mockDeleteRouteStart = jest.fn();
+const mockPutActiveRoute = jest.fn();
+const mockGetActiveRoute = jest.fn();
+const mockDeleteActiveRoute = jest.fn();
 let mockSend: jest.Mock;
 const mockPublishStarted = jest.fn();
 const mockPublishFinished = jest.fn();
@@ -26,9 +26,9 @@ jest.mock(
   "../../../users/infrastructure/dynamodb/dynamo-user-activity-repository",
   () => ({
     DynamoUserActivityRepository: jest.fn().mockImplementation(() => ({
-      putRouteStart: (...args: any[]) => mockPutRouteStart(...args),
-      getRouteStart: (...args: any[]) => mockGetRouteStart(...args),
-      deleteRouteStart: (...args: any[]) => mockDeleteRouteStart(...args),
+      putActiveRoute: (...args: any[]) => mockPutActiveRoute(...args),
+      getActiveRoute: (...args: any[]) => mockGetActiveRoute(...args),
+      deleteActiveRoute: (...args: any[]) => mockDeleteActiveRoute(...args),
     })),
   })
 );
@@ -67,9 +67,9 @@ beforeEach(() => {
   mockFindAll.mockReset();
   mockFindByJobId.mockReset();
   mockSave.mockReset();
-  mockPutRouteStart.mockReset();
-  mockGetRouteStart.mockReset();
-  mockDeleteRouteStart.mockReset();
+  mockPutActiveRoute.mockReset();
+  mockGetActiveRoute.mockReset();
+  mockDeleteActiveRoute.mockReset();
   mockSend.mockReset();
   mockPublishStarted.mockReset();
   mockPublishFinished.mockReset();
@@ -295,7 +295,7 @@ describe("telemetry started", () => {
     });
     expect(mockSend).toHaveBeenCalledTimes(1);
     expect(mockSave).toHaveBeenCalledWith(route);
-    expect(mockPutRouteStart).toHaveBeenCalledWith(
+    expect(mockPutActiveRoute).toHaveBeenCalledWith(
       "test@example.com",
       routeId,
       expect.any(Number)
@@ -346,7 +346,7 @@ describe("finish route", () => {
     route.description = "desc";
     route.start();
     mockFindById.mockResolvedValueOnce(route);
-    mockGetRouteStart.mockResolvedValueOnce(1000);
+    mockGetActiveRoute.mockResolvedValueOnce({ startedAt: 1000 });
     mockSend.mockResolvedValueOnce({});
 
     const res = await handler({
@@ -354,11 +354,11 @@ describe("finish route", () => {
       pathParameters: { routeId: route.routeId.Value },
     });
 
-    expect(mockGetRouteStart).toHaveBeenCalledWith(
+    expect(mockGetActiveRoute).toHaveBeenCalledWith(
       "test@example.com",
       route.routeId.Value
     );
-    expect(mockDeleteRouteStart).toHaveBeenCalledWith(
+    expect(mockDeleteActiveRoute).toHaveBeenCalledWith(
       "test@example.com",
       route.routeId.Value
     );

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -235,7 +235,7 @@ export const handler = base(async (
     }
 
     const ts = Date.now();
-    await userActivityRepository.putRouteStart(email, routeId, ts);
+    await userActivityRepository.putActiveRoute(email, routeId, ts);
     const started = await startRouteUseCase.execute({
       routeId: UUID.fromString(routeId),
       email,
@@ -258,11 +258,11 @@ export const handler = base(async (
     }
 
     const finishTs = Date.now();
-    const startTs = await userActivityRepository.getRouteStart(email, routeId);
-    if (startTs != null) {
-      await userActivityRepository.deleteRouteStart(email, routeId);
+    const active = await userActivityRepository.getActiveRoute(email, routeId);
+    if (active) {
+      await userActivityRepository.deleteActiveRoute(email, routeId);
     }
-    const actualDurationMs = startTs != null ? finishTs - startTs : undefined;
+    const actualDurationMs = active ? finishTs - active.startedAt : undefined;
     const actualDuration =
       actualDurationMs != null
         ? Math.round(actualDurationMs / 1000)

--- a/src/backend/src/users/domain/repositories/user-activity-repository.ts
+++ b/src/backend/src/users/domain/repositories/user-activity-repository.ts
@@ -1,10 +1,22 @@
+export interface ActiveRoute {
+  startedAt: number;
+  checkpointIndex?: number;
+  finishedAt?: number;
+}
+
 export interface UserActivityRepository {
-  /** Store the start timestamp for a route execution */
-  putRouteStart(email: string, routeId: string, timestamp: number): Promise<void>;
+  /** Store the active route information for a user */
+  putActiveRoute(
+    email: string,
+    routeId: string,
+    startedAt: number,
+    checkpointIndex?: number,
+    finishedAt?: number
+  ): Promise<void>;
 
-  /** Retrieve the start timestamp previously stored for a route execution */
-  getRouteStart(email: string, routeId: string): Promise<number | null>;
+  /** Retrieve the active route information for a user */
+  getActiveRoute(email: string, routeId: string): Promise<ActiveRoute | null>;
 
-  /** Remove the start timestamp once the route is finished */
-  deleteRouteStart(email: string, routeId: string): Promise<void>;
+  /** Remove the active route information once the route is finished */
+  deleteActiveRoute(email: string, routeId: string): Promise<void>;
 }

--- a/src/backend/src/users/infrastructure/dynamodb/dynamo-user-activity-repository.test.ts
+++ b/src/backend/src/users/infrastructure/dynamodb/dynamo-user-activity-repository.test.ts
@@ -19,35 +19,40 @@ describe('DynamoUserActivityRepository', () => {
     repo = new DynamoUserActivityRepository(client, tableName);
   });
 
-  it('stores route start timestamp', async () => {
-    await repo.putRouteStart(email, routeId, 123);
+  it('stores active route information', async () => {
+    process.env.ACTIVE_ROUTE_TTL = '60';
+    await repo.putActiveRoute(email, routeId, 123);
     const cmd = mockSend.mock.calls[0][0];
     expect(cmd).toBeInstanceOf(PutItemCommand);
     expect((cmd as any).input).toEqual({
       TableName: tableName,
       Item: {
         PK: { S: `USER#${email}` },
-        SK: { S: `START#${routeId}` },
-        timestamp: { N: '123' },
+        SK: { S: `ACTIVE_ROUTE#${routeId}` },
+        startedAt: { N: '123' },
+        ttl: { N: '60' },
       },
     });
+    delete process.env.ACTIVE_ROUTE_TTL;
   });
 
-  it('retrieves start timestamp', async () => {
-    mockSend.mockResolvedValueOnce({ Item: { timestamp: { N: '456' } } });
-    const ts = await repo.getRouteStart(email, routeId);
+  it('retrieves active route information', async () => {
+    mockSend.mockResolvedValueOnce({
+      Item: { startedAt: { N: '456' }, checkpointIndex: { N: '2' } },
+    });
+    const info = await repo.getActiveRoute(email, routeId);
     const cmd = mockSend.mock.calls[0][0];
     expect(cmd).toBeInstanceOf(GetItemCommand);
-    expect(ts).toBe(456);
+    expect(info).toEqual({ startedAt: 456, checkpointIndex: 2 });
   });
 
-  it('deletes start timestamp', async () => {
-    await repo.deleteRouteStart(email, routeId);
+  it('deletes active route information', async () => {
+    await repo.deleteActiveRoute(email, routeId);
     const cmd = mockSend.mock.calls[0][0];
     expect(cmd).toBeInstanceOf(DeleteItemCommand);
     expect((cmd as any).input).toEqual({
       TableName: tableName,
-      Key: { PK: { S: `USER#${email}` }, SK: { S: `START#${routeId}` } },
+      Key: { PK: { S: `USER#${email}` }, SK: { S: `ACTIVE_ROUTE#${routeId}` } },
     });
   });
 });

--- a/src/backend/src/users/infrastructure/dynamodb/dynamo-user-activity-repository.ts
+++ b/src/backend/src/users/infrastructure/dynamodb/dynamo-user-activity-repository.ts
@@ -4,44 +4,72 @@ import {
   DeleteItemCommand,
   GetItemCommand,
 } from "@aws-sdk/client-dynamodb";
-import { UserActivityRepository } from "../../domain/repositories/user-activity-repository";
+import {
+  ActiveRoute,
+  UserActivityRepository,
+} from "../../domain/repositories/user-activity-repository";
 
 export class DynamoUserActivityRepository implements UserActivityRepository {
   constructor(private client: DynamoDBClient, private tableName: string) {}
 
-  async putRouteStart(
+  async putActiveRoute(
     email: string,
     routeId: string,
-    timestamp: number
+    startedAt: number,
+    checkpointIndex?: number,
+    finishedAt?: number
   ): Promise<void> {
+    const item: any = {
+      PK: { S: `USER#${email}` },
+      SK: { S: `ACTIVE_ROUTE#${routeId}` },
+      startedAt: { N: startedAt.toString() },
+    };
+    if (checkpointIndex != null)
+      item.checkpointIndex = { N: checkpointIndex.toString() };
+    if (finishedAt != null) item.finishedAt = { N: finishedAt.toString() };
+
+    const ttlEnv = process.env.ACTIVE_ROUTE_TTL;
+    if (ttlEnv) {
+      const ttlSeconds = parseInt(ttlEnv, 10);
+      if (!isNaN(ttlSeconds)) {
+        item.ttl = {
+          N: (Math.floor(startedAt / 1000) + ttlSeconds).toString(),
+        };
+      }
+    }
+
     await this.client.send(
-      new PutItemCommand({
-        TableName: this.tableName,
-        Item: {
-          PK: { S: `USER#${email}` },
-          SK: { S: `START#${routeId}` },
-          timestamp: { N: timestamp.toString() },
-        },
-      })
+      new PutItemCommand({ TableName: this.tableName, Item: item })
     );
   }
 
-  async getRouteStart(email: string, routeId: string): Promise<number | null> {
+  async getActiveRoute(
+    email: string,
+    routeId: string
+  ): Promise<ActiveRoute | null> {
     const res = await this.client.send(
       new GetItemCommand({
         TableName: this.tableName,
-        Key: { PK: { S: `USER#${email}` }, SK: { S: `START#${routeId}` } },
+        Key: { PK: { S: `USER#${email}` }, SK: { S: `ACTIVE_ROUTE#${routeId}` } },
       })
     );
-    if (!res.Item || !res.Item.timestamp) return null;
-    return parseInt(res.Item.timestamp.N!, 10);
+    const item = res.Item;
+    if (!item || !item.startedAt) return null;
+    const result: ActiveRoute = {
+      startedAt: parseInt(item.startedAt.N!, 10),
+    };
+    if (item.checkpointIndex)
+      result.checkpointIndex = parseInt(item.checkpointIndex.N!, 10);
+    if (item.finishedAt)
+      result.finishedAt = parseInt(item.finishedAt.N!, 10);
+    return result;
   }
 
-  async deleteRouteStart(email: string, routeId: string): Promise<void> {
+  async deleteActiveRoute(email: string, routeId: string): Promise<void> {
     await this.client.send(
       new DeleteItemCommand({
         TableName: this.tableName,
-        Key: { PK: { S: `USER#${email}` }, SK: { S: `START#${routeId}` } },
+        Key: { PK: { S: `USER#${email}` }, SK: { S: `ACTIVE_ROUTE#${routeId}` } },
       })
     );
   }


### PR DESCRIPTION
## Summary
- rename user activity entries to ACTIVE_ROUTE and include startedAt, checkpointIndex, finishedAt fields
- store TTL for active route entries based on start time
- update page router and tests for new repository API

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68bd5e71494c832f87317514c5a42f3d