### PR TITLE
chore: install browsers before e2e tests

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "pretest:e2e": "playwright install",
     "test:e2e": "playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- install Playwright browsers before running e2e tests to avoid missing executable errors

## Testing
- `npm run test:e2e` *(fails: 403 Forbidden when downloading Chromium)*
- `npm run lint` *(fails: thousands of no-undef errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdabc1d814832fa2de82b77be3b1b2