### PR TITLE
fix: update profile endpoint

### DIFF
--- a/src/frontend/src/components/auth/LoginForm.tsx
+++ b/src/frontend/src/components/auth/LoginForm.tsx
@@ -55,7 +55,7 @@ const LoginForm: React.FC<Props> = ({ onSuccess }) => {
       localStorage.setItem('refreshToken', refresh);
       setSession(id, refresh);
       await api.put(
-        '/profile',
+        '/v1/profile',
         { email },
         {
           headers: { Authorization: `Bearer ${id}` },


### PR DESCRIPTION
## Summary
- fix login form profile sync endpoint path to use `/v1/profile`

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm run test:e2e` *(fails: Failed to download Chromium 139.0.7258.5 (playwright build v1181), caused by Download failure, code=1)*

------
https://chatgpt.com/codex/tasks/task_e_68bdea16e78c832f963799e8d42cd5be