### PR TITLE
Allow mixed Accept headers for profile routes

### DIFF
--- a/src/backend/src/users/interfaces/http/profile-routes.test.ts
+++ b/src/backend/src/users/interfaces/http/profile-routes.test.ts
@@ -50,6 +50,27 @@ describe("profile routes handler", () => {
     expect(JSON.parse(res.body)).toEqual(profile.toPrimitives());
   });
 
+  it("supports mixed Accept headers", async () => {
+    const profile = UserProfile.fromPrimitives({ email: "test@example.com" });
+    mockGetProfile.mockResolvedValueOnce(profile);
+    const res = await handler({
+      ...baseCtx,
+      headers: { Accept: "text/plain, application/json" },
+      httpMethod: "GET",
+    } as any);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(profile.toPrimitives());
+  });
+
+  it("returns 415 when Accept header missing application/json", async () => {
+    const res = await handler({
+      ...baseCtx,
+      headers: { Accept: "text/plain" },
+      httpMethod: "GET",
+    } as any);
+    expect(res.statusCode).toBe(415);
+  });
+
   it("creates profile when missing", async () => {
     mockGetProfile.mockResolvedValueOnce(null);
     const res = await handler({ ...baseCtx, httpMethod: "GET" } as any);

--- a/src/backend/src/users/interfaces/http/profile-routes.ts
+++ b/src/backend/src/users/interfaces/http/profile-routes.ts
@@ -24,7 +24,7 @@ export const handler = base(async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   const accept = event.headers?.Accept || event.headers?.accept;
-  if (accept !== "application/json") {
+  if (!accept?.includes("application/json")) {
     return {
       statusCode: 415,
       headers: jsonHeaders,

--- a/src/backend/test/integration/profile-routes.integration.test.ts
+++ b/src/backend/test/integration/profile-routes.integration.test.ts
@@ -60,6 +60,22 @@ describe("profile routes integration", () => {
     expect(JSON.parse(res.body)).toEqual({ email, firstName: "John" });
   });
 
+  it("accepts mixed Accept headers", async () => {
+    store.set(key, {
+      PK: { S: `USER#${email}` },
+      SK: { S: "PROFILE" },
+      email: { S: email },
+    });
+
+    const res = await handler({
+      ...baseEvent,
+      headers: { Accept: "text/plain, application/json" },
+      httpMethod: "GET",
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
   it("updates profile on PUT", async () => {
     // Seed initial profile
     store.set(key, {
@@ -90,6 +106,16 @@ describe("profile routes integration", () => {
       code: 401,
       message: "Unauthorized",
     });
+  });
+
+  it("returns 415 when Accept header missing application/json", async () => {
+    const res = await handler({
+      ...baseEvent,
+      headers: { Accept: "text/plain" },
+      httpMethod: "GET",
+    });
+
+    expect(res.statusCode).toBe(415);
   });
 });
 


### PR DESCRIPTION
## Summary
- allow `profile-routes` to accept mixed `Accept` headers
- test profile routes against mixed and unsupported `Accept` header values

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68bdf26cd7ec832f9075adf9a32ec42a