### PR TITLE
Add JSON headers to profile update on login

### DIFF
--- a/src/frontend/src/components/auth/LoginForm.tsx
+++ b/src/frontend/src/components/auth/LoginForm.tsx
@@ -58,7 +58,11 @@ const LoginForm: React.FC<Props> = ({ onSuccess }) => {
         '/v1/profile',
         { email },
         {
-          headers: { Authorization: `Bearer ${id}` },
+          headers: {
+            Authorization: `Bearer ${id}`,
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
         },
       );
       onSuccess?.();


### PR DESCRIPTION
## Summary
- include `Accept` and `Content-Type` headers when updating profile during login

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: Missing script "test:unit")*

------
https://chatgpt.com/codex/tasks/task_e_68bdf26e32f4832fae6af0afe2008134