### PR TITLE
Use access tokens for session management

### DIFF
--- a/src/frontend/src/auth/AuthProvider.tsx
+++ b/src/frontend/src/auth/AuthProvider.tsx
@@ -1,28 +1,29 @@
 import { useState, useEffect, type ReactNode } from 'react';
 import { AuthContext } from '../contexts/AuthContext';
 
-export let externalSetSession: ((id: string, refresh: string) => void) | null =
-  null;
+export let externalSetSession:
+  | ((access: string, refresh: string) => void)
+  | null = null;
 export let externalSignOut: (() => void) | null = null;
 
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const [idToken, setIdToken] = useState<string | null>(
-    () => localStorage.getItem('idToken')
+  const [accessToken, setAccessToken] = useState<string | null>(
+    () => localStorage.getItem('accessToken')
   );
   const [refreshToken, setRefreshToken] = useState<string | null>(
     () => localStorage.getItem('refreshToken')
   );
 
-  const setSession = (id: string, refresh: string) => {
-    setIdToken(id);
+  const setSession = (access: string, refresh: string) => {
+    setAccessToken(access);
     setRefreshToken(refresh);
   };
 
   const signOut = () => {
-    setIdToken(null);
+    setAccessToken(null);
     setRefreshToken(null);
-    localStorage.removeItem('idToken');
+    localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
   };
 
@@ -30,12 +31,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   externalSignOut = signOut;
 
   useEffect(() => {
-    if (idToken) {
-      localStorage.setItem('idToken', idToken);
+    if (accessToken) {
+      localStorage.setItem('accessToken', accessToken);
     } else {
-      localStorage.removeItem('idToken');
+      localStorage.removeItem('accessToken');
     }
-  }, [idToken]);
+  }, [accessToken]);
 
   useEffect(() => {
     if (refreshToken) {
@@ -47,7 +48,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   return (
     <AuthContext.Provider
-      value={{ idToken, refreshToken, setSession, signOut }}
+      value={{ accessToken, refreshToken, setSession, signOut }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/frontend/src/components/NavBar.tsx
+++ b/src/frontend/src/components/NavBar.tsx
@@ -19,7 +19,7 @@ import logoSrc from '../assets/logo.png';
 import { AuthContext } from '../contexts/AuthContext';
 
 const NavBar = () => {
-  const { idToken, signOut } = useContext(AuthContext);
+  const { accessToken, signOut } = useContext(AuthContext);
   const linkColor = useColorModeValue('gray.600', 'gray.300');
   const linkHover = useColorModeValue('brand.600', 'brand.400');
 
@@ -57,7 +57,7 @@ const NavBar = () => {
             Home
           </Link>
 
-          {!idToken && (
+          {!accessToken && (
             <>
               <Link
                 as={RouterLink}
@@ -78,7 +78,7 @@ const NavBar = () => {
             </>
           )}
 
-          {idToken && (
+          {accessToken && (
             <Menu>
               <MenuButton
                 as={IconButton}

--- a/src/frontend/src/components/ProtectedRoute.tsx
+++ b/src/frontend/src/components/ProtectedRoute.tsx
@@ -3,8 +3,8 @@ import { Navigate } from 'react-router-dom';
 import { AuthContext } from '../contexts/AuthContext';
 
 const ProtectedRoute = ({ children }: { children: JSX.Element }) => {
-  const { idToken } = useContext(AuthContext);
-  if (!idToken) {
+  const { accessToken } = useContext(AuthContext);
+  if (!accessToken) {
     return <Navigate to="/login" />;
   }
   return children;

--- a/src/frontend/src/components/auth/LoginForm.tsx
+++ b/src/frontend/src/components/auth/LoginForm.tsx
@@ -49,17 +49,17 @@ const LoginForm: React.FC<Props> = ({ onSuccess }) => {
     }
     try {
       const session = await signIn(email, password);
-      const id = session.getIdToken().getJwtToken();
+      const access = session.getAccessToken().getJwtToken();
       const refresh = session.getRefreshToken().getToken();
-      localStorage.setItem('idToken', id);
+      localStorage.setItem('accessToken', access);
       localStorage.setItem('refreshToken', refresh);
-      setSession(id, refresh);
+      setSession(access, refresh);
       await api.put(
         '/v1/profile',
         { email },
         {
           headers: {
-            Authorization: `Bearer ${id}`,
+            Authorization: `Bearer ${access}`,
             'Content-Type': 'application/json',
             Accept: 'application/json',
           },

--- a/src/frontend/src/contexts/AuthContext.ts
+++ b/src/frontend/src/contexts/AuthContext.ts
@@ -1,14 +1,14 @@
 import { createContext } from 'react';
 
 export interface AuthContextType {
-  idToken: string | null;
+  accessToken: string | null;
   refreshToken: string | null;
-  setSession: (idToken: string, refreshToken: string) => void;
+  setSession: (accessToken: string, refreshToken: string) => void;
   signOut: () => void;
 }
 
 export const AuthContext = createContext<AuthContextType>({
-  idToken: null,
+  accessToken: null,
   refreshToken: null,
   setSession: () => {},
   signOut: () => {},

--- a/src/frontend/src/pages/HomePage.tsx
+++ b/src/frontend/src/pages/HomePage.tsx
@@ -10,11 +10,11 @@ import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../contexts/AuthContext';
 
 const HomePage = () => {
-  const { idToken } = useContext(AuthContext);
+  const { accessToken } = useContext(AuthContext);
   const navigate = useNavigate();
 
   const handleStart = () => {
-    navigate(idToken ? '/routes' : '/login');
+    navigate(accessToken ? '/routes' : '/login');
   };
 
   return (

--- a/src/frontend/src/services/api.ts
+++ b/src/frontend/src/services/api.ts
@@ -27,30 +27,30 @@ function isTokenExpired(token: string): boolean {
 }
 
 api.interceptors.request.use(async (config) => {
-  let idToken = localStorage.getItem('idToken');
+  let accessToken = localStorage.getItem('accessToken');
   const refreshToken = localStorage.getItem('refreshToken');
 
-  if (idToken && refreshToken && isTokenExpired(idToken)) {
+  if (accessToken && refreshToken && isTokenExpired(accessToken)) {
     const user = getCurrentUser();
     if (user) {
       try {
         const session = await refreshSession(user, refreshToken);
-        idToken = session.getIdToken().getJwtToken();
+        accessToken = session.getAccessToken().getJwtToken();
         const newRefresh = session.getRefreshToken().getToken();
-        localStorage.setItem('idToken', idToken);
+        localStorage.setItem('accessToken', accessToken);
         localStorage.setItem('refreshToken', newRefresh);
-        externalSetSession?.(idToken, newRefresh);
+        externalSetSession?.(accessToken, newRefresh);
       } catch {
-        localStorage.removeItem('idToken');
+        localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
         externalSignOut?.();
       }
     }
   }
 
-  if (idToken) {
+  if (accessToken) {
     config.headers = config.headers || {};
-    config.headers['Authorization'] = `Bearer ${idToken}`;
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
   }
   return config;
 });


### PR DESCRIPTION
## Summary
- Store Cognito access token after login and send with `/v1/profile` requests
- Replace id token usage with access token in AuthContext, AuthProvider, and API service
- Update components to reference `accessToken` and attach it in request headers

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: Download failed: server returned code 403 body 'Forbidden'. URL: https://cdn.playwright.dev/builds/chromium/1181/chromium-linux.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfdedec98832fb67ce55be7f8f843