### PR TITLE
Add CORS headers to API gateway error responses

### DIFF
--- a/infrastructure/lib/stacks/compute-stack.test.ts
+++ b/infrastructure/lib/stacks/compute-stack.test.ts
@@ -88,4 +88,22 @@ describe("ComputeStack", () => {
       },
     });
   });
+
+  test("configures gateway responses with CORS headers", () => {
+    const headers = {
+      "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+      "gatewayresponse.header.Access-Control-Allow-Headers": "'*'",
+      "gatewayresponse.header.Access-Control-Allow-Methods": "'GET,POST,PUT,DELETE,OPTIONS'",
+    };
+
+    template.hasResourceProperties("AWS::ApiGateway::GatewayResponse", {
+      ResponseType: "UNAUTHORIZED",
+      ResponseParameters: headers,
+    });
+
+    template.hasResourceProperties("AWS::ApiGateway::GatewayResponse", {
+      ResponseType: "DEFAULT_4XX",
+      ResponseParameters: headers,
+    });
+  });
 });

--- a/infrastructure/lib/stacks/compute-stack.ts
+++ b/infrastructure/lib/stacks/compute-stack.ts
@@ -52,6 +52,24 @@ export class ComputeStack extends cdk.Stack {
       exportName: `SendeoApiUrl-${suffix}`,
     });
 
+    api.addGatewayResponse("UnauthorizedResponse", {
+      type: apigw.ResponseType.UNAUTHORIZED,
+      responseHeaders: {
+        "Access-Control-Allow-Origin": "'*'",
+        "Access-Control-Allow-Headers": "'*'",
+        "Access-Control-Allow-Methods": "'GET,POST,PUT,DELETE,OPTIONS'",
+      },
+    });
+
+    api.addGatewayResponse("Default4xxResponse", {
+      type: apigw.ResponseType.DEFAULT_4XX,
+      responseHeaders: {
+        "Access-Control-Allow-Origin": "'*'",
+        "Access-Control-Allow-Headers": "'*'",
+        "Access-Control-Allow-Methods": "'GET,POST,PUT,DELETE,OPTIONS'",
+      },
+    });
+
     const authorizer = new apigw.CognitoUserPoolsAuthorizer(
       this,
       "CognitoAuth",


### PR DESCRIPTION
## Summary
- add gateway responses for 401 and 4XX errors with CORS headers
- test API gateway error responses include CORS headers

## Testing
- `npm run test:unit` (infrastructure)
- `npm run test:unit` (src/backend)
- `npm run test:e2e` (src/frontend) *(fails: Failed to download Chromium 139.0.7258.5)*

------
https://chatgpt.com/codex/tasks/task_e_68be001222c4832f9a8f173f9743c981