### PR TITLE
refactor: update route imports and fix build

### DIFF
--- a/src/backend/src/auth/triggers/pre-signup.test.ts
+++ b/src/backend/src/auth/triggers/pre-signup.test.ts
@@ -28,7 +28,7 @@ describe("pre-signup trigger", () => {
     process.env.STAGE = "dev";
     const event = createEvent("user@any.com");
 
-    const res = await handler(event);
+    const res = (await (handler as any)(event)) as PreSignUpTriggerEvent;
 
     expect(res.response.autoConfirmUser).toBe(true);
     expect(res.response.autoVerifyEmail).toBe(true);
@@ -39,7 +39,7 @@ describe("pre-signup trigger", () => {
     process.env.ALLOWED_EMAIL_DOMAIN = "example.com";
     const event = createEvent("user@example.com");
 
-    const res = await handler(event);
+    const res = (await (handler as any)(event)) as PreSignUpTriggerEvent;
 
     expect(res.response.autoConfirmUser).toBe(true);
     expect(res.response.autoVerifyEmail).toBe(true);
@@ -50,7 +50,7 @@ describe("pre-signup trigger", () => {
     process.env.ALLOWED_EMAIL_DOMAIN = "example.com";
     const event = createEvent("user@other.com");
 
-    const res = await handler(event);
+    const res = (await (handler as any)(event)) as PreSignUpTriggerEvent;
 
     expect(res.response.autoConfirmUser).toBeUndefined();
     expect(res.response.autoVerifyEmail).toBeUndefined();
@@ -61,7 +61,7 @@ describe("pre-signup trigger", () => {
     process.env.ALLOWED_EMAIL_DOMAIN = "example.com";
     const event = createEvent("user@example.com");
 
-    const res = await handler(event);
+    const res = (await (handler as any)(event)) as PreSignUpTriggerEvent;
 
     expect(res.response.autoConfirmUser).toBeUndefined();
     expect(res.response.autoVerifyEmail).toBeUndefined();

--- a/src/backend/src/routes/application/use-cases/finish-route.ts
+++ b/src/backend/src/routes/application/use-cases/finish-route.ts
@@ -1,8 +1,8 @@
 import { RouteRepository } from "../../domain/repositories/route-repository";
 import { EventDispatcher } from "../../../shared/domain/events/event-dispatcher";
-import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
+import { UUID } from "../../../shared/domain/value-objects/uuid";
 import { RouteFinishedEvent } from "../../domain/events/route-finished";
-import { Route } from "../../domain/entities/route-entity";
+import { Route } from "../../domain/entities/route";
 
 export interface FinishRouteInput {
   readonly routeId: UUID;

--- a/src/backend/src/routes/application/use-cases/start-route.ts
+++ b/src/backend/src/routes/application/use-cases/start-route.ts
@@ -1,8 +1,8 @@
 import { RouteRepository } from "../../domain/repositories/route-repository";
 import { EventDispatcher } from "../../../shared/domain/events/event-dispatcher";
-import { UUID } from "../../../shared/domain/value-objects/uuid-value-object";
+import { UUID } from "../../../shared/domain/value-objects/uuid";
 import { RouteStartedEvent } from "../../domain/events/route-started";
-import { Route } from "../../domain/entities/route-entity";
+import { Route } from "../../domain/entities/route";
 
 export interface StartRouteInput {
   readonly routeId: UUID;

--- a/src/backend/src/routes/domain/entities/route.ts
+++ b/src/backend/src/routes/domain/entities/route.ts
@@ -10,11 +10,11 @@ import { RouteStatus } from "../value-objects/route-status";
 export interface RouteProps {
   readonly routeId: UUID;
   readonly jobId?: UUID;
-  readonly distanceKm?: DistanceKm;
-  readonly duration?: Duration;
-  readonly path?: Path;
-  readonly description?: string;
-  readonly status: RouteStatus;
+  distanceKm?: DistanceKm;
+  duration?: Duration;
+  path?: Path;
+  description?: string;
+  status: RouteStatus;
 }
 
 export class Route {

--- a/src/backend/src/routes/domain/events/route-finished.ts
+++ b/src/backend/src/routes/domain/events/route-finished.ts
@@ -1,5 +1,5 @@
 import { DomainEvent } from "../../../shared/domain/events/domain-event";
-import { Route } from "../entities/route-entity";
+import { Route } from "../entities/route";
 
 export interface RouteFinishedProps {
   readonly route: Route;

--- a/src/backend/src/routes/domain/events/route-started.ts
+++ b/src/backend/src/routes/domain/events/route-started.ts
@@ -1,5 +1,5 @@
 import { DomainEvent } from "../../../shared/domain/events/domain-event";
-import { Route } from "../entities/route-entity";
+import { Route } from "../entities/route";
 
 export interface RouteStartedProps {
   readonly route: Route;

--- a/src/backend/src/routes/domain/services/route-generator.ts
+++ b/src/backend/src/routes/domain/services/route-generator.ts
@@ -138,7 +138,7 @@ export class RouteGenerator {
       })
       .filter(
         (
-          x
+          x: unknown
         ): x is {
           distanceMeters: number;
           durationSeconds: number;

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
@@ -325,12 +325,12 @@ describe("worker routes handler", () => {
   });
 
   it("merges back leg coordinates with minor differences", async () => {
-    const forwardCoords = [
+    const forwardCoords: [number, number][] = [
       [38.5, -120.2],
       [40.7, -120.95],
       [43.252, -126.453],
     ];
-    const backCoords = [
+    const backCoords: [number, number][] = [
       [43.252001, -126.453001],
       [40.7, -120.95],
       [38.5, -120.2],

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.ts
@@ -127,7 +127,7 @@ async function computeRoutes(
     })
     .filter(
       (
-        x
+        x: unknown
       ): x is {
         distanceMeters: number;
         durationSeconds: number;

--- a/src/backend/src/users/application/use-cases/add-favourite.usecase.test.ts
+++ b/src/backend/src/users/application/use-cases/add-favourite.usecase.test.ts
@@ -1,8 +1,9 @@
 import { AddFavouriteUseCase, FavouriteAlreadyExistsError } from './add-favourite';
 import { UserProfileRepository } from '../../domain/repositories/user-profile-repository';
+import { Email } from '../../../shared/domain/value-objects/email';
 
 describe('AddFavouriteUseCase', () => {
-  const email = 'user@example.com';
+  const email = Email.fromString('user@example.com');
   const routeId = '1';
   it('adds favourite when not existing', async () => {
     const repo: UserProfileRepository = {

--- a/src/backend/src/users/application/use-cases/remove-favourite.usecase.test.ts
+++ b/src/backend/src/users/application/use-cases/remove-favourite.usecase.test.ts
@@ -1,5 +1,6 @@
 import { RemoveFavouriteUseCase } from './remove-favourite';
 import { UserProfileRepository } from '../../domain/repositories/user-profile-repository';
+import { Email } from '../../../shared/domain/value-objects/email';
 
 describe('RemoveFavouriteUseCase', () => {
   it('calls deleteFavourite with provided params', async () => {
@@ -7,7 +8,8 @@ describe('RemoveFavouriteUseCase', () => {
       deleteFavourite: jest.fn(),
     } as any;
     const useCase = new RemoveFavouriteUseCase(repo);
-    await useCase.execute('user@example.com', '1');
-    expect(repo.deleteFavourite).toHaveBeenCalledWith('user@example.com', '1');
+    const email = Email.fromString('user@example.com');
+    await useCase.execute(email, '1');
+    expect(repo.deleteFavourite).toHaveBeenCalledWith(email, '1');
   });
 });

--- a/src/backend/test/integration/rate-limit.integration.test.ts
+++ b/src/backend/test/integration/rate-limit.integration.test.ts
@@ -18,7 +18,7 @@ describe("rate limit middleware", () => {
     await handler(baseEvent);
     const res = await handler(baseEvent);
     expect(res.statusCode).toBe(429);
-    expect(res.headers["Retry-After"]).toBeDefined();
+    expect(res.headers!["Retry-After"]).toBeDefined();
   });
 
   it("logs attempts", async () => {

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -21,7 +21,8 @@
     "typeRoots": ["./node_modules/@types"],
     "isolatedModules": true,
     "types": ["node", "jest"],
-    "outDir": "dist"
+    "outDir": "dist",
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- update UUID and Route imports across route use cases and events
- fix type definitions and tests for new Route entity
- enable build by skipping lib checks

## Testing
- `npm --prefix src/backend run build`
- `npm --prefix src/backend run test:unit`
- `npm --prefix src/frontend run test:e2e` *(fails: Download failed: server returned code 403 body 'Forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68bea8954874832f87b4174914b2d689