### PR TITLE
Handle profile update failures during login

### DIFF
--- a/src/frontend/src/components/auth/LoginForm.tsx
+++ b/src/frontend/src/components/auth/LoginForm.tsx
@@ -54,17 +54,21 @@ const LoginForm: React.FC<Props> = ({ onSuccess }) => {
       localStorage.setItem('idToken', id);
       localStorage.setItem('refreshToken', refresh);
       setSession(id, refresh);
-      await api.put(
-        '/v1/profile',
-        { email },
-        {
-          headers: {
-            Authorization: `Bearer ${id}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
+      try {
+        await api.put(
+          '/v1/profile',
+          { email },
+          {
+            headers: {
+              Authorization: `Bearer ${id}`,
+              'Content-Type': 'application/json',
+              Accept: 'application/json',
+            },
           },
-        },
-      );
+        );
+      } catch (err) {
+        console.error('Failed to update profile', err);
+      }
       onSuccess?.();
     } catch {
       toast({ title: 'Invalid email or password', status: 'error' });


### PR DESCRIPTION
## Summary
- avoid failing login when profile update request returns errors

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: server returned code 403 when downloading Playwright binaries)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bead29a0e8832f865157404c82fe15