### PR TITLE
chore: remove maxDeltaKm test

### DIFF
--- a/src/backend/src/routes/interfaces/http/request-routes.test.ts
+++ b/src/backend/src/routes/interfaces/http/request-routes.test.ts
@@ -77,18 +77,6 @@ describe("request routes handler", () => {
     });
   });
 
-  it("forwards maxDeltaKm when provided", async () => {
-    mockSend.mockResolvedValueOnce({});
-    await handler({
-      headers: { Accept: "application/json" },
-      body: JSON.stringify({ origin: "A", destination: "B", maxDeltaKm: "1" }),
-    } as any);
-
-    expect(mockSend).toHaveBeenCalledTimes(1);
-    const payload = JSON.parse(mockSend.mock.calls[0][0].MessageBody);
-    expect(payload.maxDeltaKm).toBe(1);
-  });
-
   it("forwards routesCount when provided", async () => {
     mockSend.mockResolvedValueOnce({});
     await handler({


### PR DESCRIPTION
## Summary
- remove request-routes test case for maxDeltaKm
- ensure remaining tests have no maxDeltaKm references

## Testing
- `rg maxDeltaKm -g '*test*' -n`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68bf4ce07604832f98bdc99cce277363