### PR TITLE
Revert map provider integration

### DIFF
--- a/src/backend/src/routes/application/use-cases/describe-route.ts
+++ b/src/backend/src/routes/application/use-cases/describe-route.ts
@@ -1,7 +1,6 @@
 import { RouteRepository } from "../../domain/repositories/route-repository";
 import { Route } from "../../domain/entities/route";
 import { UUID } from "../../../shared/domain/value-objects/uuid";
-import { MapProvider } from "../../domain/services/map-provider";
 import { RouteDescriptionService } from "../../domain/services/route-description-service";
 
 export class DescribeRouteUseCase {
@@ -10,15 +9,14 @@ export class DescribeRouteUseCase {
     private routeDescriptionService: RouteDescriptionService
   ) {}
 
-  async execute(id: UUID, mapProvider: MapProvider): Promise<Route | null> {
+  async execute(id: UUID): Promise<Route | null> {
     const route = await this.repository.findById(id);
     if (!route) return null;
 
     if (!route.description && route.path) {
       try {
         const desc = await this.routeDescriptionService.describe(
-          route.path.Encoded,
-          mapProvider
+          route.path.Encoded
         );
         if (desc) {
           route.description = desc;

--- a/src/backend/src/routes/application/use-cases/describe-route.usecase.test.ts
+++ b/src/backend/src/routes/application/use-cases/describe-route.usecase.test.ts
@@ -2,7 +2,6 @@ import { DescribeRouteUseCase } from './describe-route';
 import { RouteRepository } from '../../domain/repositories/route-repository';
 import { Route } from '../../domain/entities/route';
 import { UUID } from '../../../shared/domain/value-objects/uuid';
-import { MapProvider } from '../../domain/services/map-provider';
 import { Path } from '../../domain/value-objects/path';
 import { LatLng } from '../../domain/value-objects/lat-lng';
 import { RouteStatus } from '../../domain/value-objects/route-status';
@@ -23,20 +22,17 @@ describe('DescribeRouteUseCase', () => {
       findByJobId: jest.fn(),
       remove: jest.fn(),
     } as any;
-    const mapProvider: MapProvider = {
-      getCityName: jest.fn().mockResolvedValue('City'),
-    };
     const service: RouteDescriptionService = {
       describe: jest.fn().mockResolvedValue('generated description'),
     };
     const useCase = new DescribeRouteUseCase(repo, service);
 
-    const result = await useCase.execute(routeId, mapProvider);
+    const result = await useCase.execute(routeId);
 
     expect(repo.findById).toHaveBeenCalledWith(routeId);
     expect(result).toBe(route);
     expect(result?.description).toBe('generated description');
     expect(repo.save).toHaveBeenCalledWith(route);
-    expect(service.describe).toHaveBeenCalledWith(path.Encoded, mapProvider);
+    expect(service.describe).toHaveBeenCalledWith(path.Encoded);
   });
 });

--- a/src/backend/src/routes/domain/services/map-provider.ts
+++ b/src/backend/src/routes/domain/services/map-provider.ts
@@ -1,3 +1,0 @@
-export interface MapProvider {
-  getCityName(lat: number, lng: number): Promise<string>;
-}

--- a/src/backend/src/routes/domain/services/route-description-service.ts
+++ b/src/backend/src/routes/domain/services/route-description-service.ts
@@ -1,5 +1,3 @@
-import { MapProvider } from "./map-provider";
-
 export interface RouteDescriptionService {
-  describe(path: string, provider: MapProvider): Promise<string>;
+  describe(path: string): Promise<string>;
 }

--- a/src/backend/src/routes/domain/services/route-generator.test.ts
+++ b/src/backend/src/routes/domain/services/route-generator.test.ts
@@ -18,7 +18,6 @@ describe("RouteGenerator", () => {
       geocode: jest.fn().mockResolvedValue({ lat: 1.23, lng: 4.56 }),
       computeRoutes: jest.fn(),
       snapToRoad: jest.fn(),
-      getCityName: jest.fn(),
     };
     const generator = new RouteGenerator(repo, provider);
     const result = await generator.geocode("addr");
@@ -39,7 +38,6 @@ describe("RouteGenerator", () => {
       geocode: jest.fn(),
       computeRoutes: jest.fn(),
       snapToRoad: jest.fn(),
-      getCityName: jest.fn(),
     };
     const generator = new RouteGenerator(repo, provider);
     const jobId = UUID.generate().toString();

--- a/src/backend/src/routes/domain/services/route-provider.ts
+++ b/src/backend/src/routes/domain/services/route-provider.ts
@@ -1,12 +1,9 @@
-import { MapProvider } from "./map-provider";
-
 export interface RouteLeg {
   distanceMeters: number;
   durationSeconds: number;
   encoded: string;
 }
-
-export interface RouteProvider extends MapProvider {
+export interface RouteProvider {
   geocode(address: string): Promise<{ lat: number; lng: number }>;
   computeRoutes(
     origin: { lat: number; lng: number },

--- a/src/backend/src/routes/infrastructure/bedrock-route-description-service.test.ts
+++ b/src/backend/src/routes/infrastructure/bedrock-route-description-service.test.ts
@@ -1,6 +1,5 @@
 import polyline from '@mapbox/polyline';
 import { BedrockRouteDescriptionService } from './bedrock-route-description-service';
-import { MapProvider } from '../domain/services/map-provider';
 
 const sendMock = jest.fn();
 
@@ -28,15 +27,11 @@ describe('BedrockRouteDescriptionService', () => {
       [0, 0],
       [1, 1],
     ]);
-    const provider: MapProvider = {
-      getCityName: jest.fn().mockResolvedValue('TestCity'),
-    };
 
-    const result = await service.describe(path, provider);
+    const result = await service.describe(path);
 
     expect(sendMock).toHaveBeenCalled();
     expect(result).toBe('desc from bedrock');
-    expect(provider.getCityName).toHaveBeenCalled();
   });
 });
 

--- a/src/backend/src/routes/infrastructure/google-maps/google-routes-provider.ts
+++ b/src/backend/src/routes/infrastructure/google-maps/google-routes-provider.ts
@@ -119,26 +119,6 @@ export class GoogleRoutesProvider implements RouteProvider {
     }
   }
 
-  async getCityName(lat: number, lng: number): Promise<string> {
-    const url =
-      `https://maps.googleapis.com/maps/api/geocode/json` +
-      `?latlng=${lat},${lng}` +
-      `&key=${this.apiKey}` +
-      `&result_type=locality|administrative_area_level_3`;
-    try {
-      const res = await fetch(url);
-      const data: any = await res.json();
-      const comps = data?.results?.[0]?.address_components ?? [];
-      return (
-        comps.find((c: any) => c.types.includes("locality"))?.long_name ??
-        comps.find((c: any) => c.types.includes("administrative_area_level_3"))?.long_name ??
-        "Unknown"
-      );
-    } catch {
-      return "Unknown";
-    }
-  }
-
   private distanceKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }) {
     const R = 6371;
     const φ1 = (a.lat * Math.PI) / 180;

--- a/src/backend/src/routes/interfaces/http/page-router.ts
+++ b/src/backend/src/routes/interfaces/http/page-router.ts
@@ -15,8 +15,6 @@ import { jsonHeaders } from "../../../http/cors";
 import { errorResponse, errorResponseFromError } from "../../../http/error-response";
 import { base } from "../../../http/base";
 import { rateLimit } from "../../../http/rate-limit";
-import { getGoogleKey } from "../shared/utils";
-import { GoogleRoutesProvider } from "../../infrastructure/google-maps/google-routes-provider";
 import { verifyJwt } from "../../../shared/auth/verify-jwt";
 import {
   EventDispatcher,
@@ -181,12 +179,7 @@ export const handler = base(rateLimit(async (
     }
     if (!route.description && route.path) {
       try {
-        const key = await getGoogleKey();
-        const mapProvider = new GoogleRoutesProvider(key);
-        const updated = await describeRouteUseCase.execute(
-          route.routeId,
-          mapProvider
-        );
+        const updated = await describeRouteUseCase.execute(route.routeId);
         if (updated) {
           route.description = updated.description;
         }

--- a/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
@@ -27,7 +27,6 @@ const provider: RouteProvider = {
     { distanceMeters: 1000, durationSeconds: 600, encoded: "abc" },
   ],
   snapToRoad: async (pt) => pt,
-  getCityName: async () => "city",
 };
 
 const queue: QueuePublisher = { send: jest.fn() };


### PR DESCRIPTION
## Summary
- remove `MapProvider` interface and related city lookup logic
- simplify `BedrockRouteDescriptionService` and `DescribeRouteUseCase` to work without external map data
- update HTTP route handler to generate descriptions without Google Maps adapter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4aba46eac832f98e5302626684d40