### PR TITLE
Redact API key in fetchJson logging

### DIFF
--- a/src/backend/src/routes/interfaces/shared/utils.test.ts
+++ b/src/backend/src/routes/interfaces/shared/utils.test.ts
@@ -1,0 +1,37 @@
+import { fetchJson } from './utils';
+
+jest.mock('node:https', () => ({
+  request: (url: string, cb: any) => {
+    const res = {
+      on: (event: string, handler: any) => {
+        if (event === 'data') {
+          handler('{"ok":true}');
+        }
+        if (event === 'end') {
+          handler();
+        }
+      }
+    } as any;
+    cb(res);
+    return {
+      on: () => {},
+      end: () => {}
+    } as any;
+  }
+}));
+
+describe('fetchJson', () => {
+  it('redacts key parameter in logs', async () => {
+    const logs: string[] = [];
+    const originalInfo = console.info;
+    console.info = (...args: any[]) => {
+      logs.push(args.join(' '));
+    };
+
+    await fetchJson('https://example.com/path?foo=bar&key=secret123');
+
+    console.info = originalInfo;
+    expect(logs[0]).toBe('[fetchJson] GET https://example.com/path?foo=bar&key=REDACTED');
+    expect(logs[0]).not.toContain('secret123');
+  });
+});

--- a/src/backend/src/routes/interfaces/shared/utils.ts
+++ b/src/backend/src/routes/interfaces/shared/utils.ts
@@ -8,7 +8,17 @@ import * as turf from "@turf/turf";
 const sm = new SecretsManagerClient({});
 
 export function fetchJson<T = any>(url: string): Promise<T> {
-  console.info(`[fetchJson] GET ${url}`);
+  let logUrl = url;
+  try {
+    const u = new URL(url);
+    if (u.searchParams.has("key")) {
+      u.searchParams.set("key", "REDACTED");
+    }
+    logUrl = u.toString();
+  } catch {
+    // ignore url parsing errors and log original url
+  }
+  console.info(`[fetchJson] GET ${logUrl}`);
   return new Promise((resolve, reject) => {
     const req = httpsRequest(url, (res) => {
       let data = "";


### PR DESCRIPTION
## Summary
- sanitize fetchJson logging to redact `key` query parameter
- add unit test verifying API key is not logged

## Testing
- `cd src/backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c68cf6b894832fa8824032b8cf2dab