### PR TITLE
Validate worker routes message schema

### DIFF
--- a/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
+++ b/src/backend/src/routes/interfaces/sqs/worker-routes.test.ts
@@ -41,7 +41,7 @@ beforeEach(() => {
   (queue.send as jest.Mock).mockReset();
 });
 
-it("saves routes and publishes metrics", async () => {
+  it("saves routes and publishes metrics", async () => {
   const event = {
     Records: [
       {
@@ -58,8 +58,24 @@ it("saves routes and publishes metrics", async () => {
 
   await handler(event);
 
-  expect(save).toHaveBeenCalled();
-  expect(publish).toHaveBeenCalled();
-  expect(queue.send).toHaveBeenCalled();
-});
+    expect(save).toHaveBeenCalled();
+    expect(publish).toHaveBeenCalled();
+    expect(queue.send).toHaveBeenCalled();
+  });
+
+  it("skips malformed messages", async () => {
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({ version: 1 }),
+        },
+      ],
+    } as any;
+
+    await handler(event);
+
+    expect(save).not.toHaveBeenCalled();
+    expect(publish).not.toHaveBeenCalled();
+    expect(queue.send).not.toHaveBeenCalled();
+  });
 


### PR DESCRIPTION
## Summary
- add runtime schema validator for worker routes SQS messages
- ignore malformed queue records to prevent downstream errors
- test route worker behavior with malformed messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c68cf7bdcc832fa9fdc69c4b609ea0